### PR TITLE
ci: remove secret output

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,10 +20,8 @@ jobs:
         run: |
           ./BuildInstaller.bat
       - name: Code Signing Setup - Setup Certificate 
-        run: | 
-          echo "${{secrets.SM_CLIENT_CERT_FILE_B64 }}" | base64 --decode > /d/Certificate_pkcs12.p12 
-          cat /d/Certificate_pkcs12.p12 
-        shell: bash   
+        run: echo "${{secrets.SM_CLIENT_CERT_FILE_B64 }}" | base64 --decode > /d/Certificate_pkcs12.p12 
+        shell: bash
       - name: Code Signing Setup - Set variables 
         id: variables 
         run: | 


### PR DESCRIPTION
Remove printing of decoded `SM_CLIENT_CERT_FILE_B64` secret because it exposes secret and serves no purpose.