### PR TITLE
Refactor CLI to use argparse subparsers

### DIFF
--- a/src/LPM.py
+++ b/src/LPM.py
@@ -370,8 +370,10 @@ def cmd_publish(args):
 
 def cmd_list(args):
     if args.packages:
-        # Defer to npm with the supplied packages.
-        runGenericNpmCmd('list', args.packages)
+        # Defer to npm with normalized package names for consistency with
+        # other commands and scoped Loupe package handling.
+        packages, _ = _normalize_packages(args.packages)
+        runGenericNpmCmd('list', packages)
         cprint('Operation completed', 'green')
         return
     executeStandard(['npm list', '-all'])

--- a/src/LPM.py
+++ b/src/LPM.py
@@ -87,7 +87,7 @@ def _normalize_packages(raw_packages):
 
 def cmd_login(args):
     if not args.silent:
-        cprint('Please follow the prompts below to log in using valid Github credentials.', 'yellow')
+        cprint('Please follow the prompts below to log in using valid GitHub credentials.', 'yellow')
         token = input(colored('? ', 'green') + 'Enter your personal access token: ')
         login(token)
     else:
@@ -392,7 +392,7 @@ def _build_parser(prog_name):
     parser.add_argument('-s', '--silent', action='store_true',
                         help='Execute commands silently with default values and no operator prompts')
     parser.add_argument('-nc', '--nocolor', action='store_true',
-                        help='Dont color the output - to avoid dependency on termcolor')
+                        help="Don't color the output - to avoid dependency on termcolor")
     parser.add_argument('-v', '--version', action='version', version='%(prog)s: ' + __version__)
 
     sub = parser.add_subparsers(dest='cmd', metavar='command')

--- a/src/LPM.py
+++ b/src/LPM.py
@@ -86,12 +86,17 @@ def _normalize_packages(raw_packages):
 # ---------------------------------------------------------------------------
 
 def cmd_login(args):
-    if not args.silent:
+    if args.silent:
+        if not args.token:
+            print(colored('Error: --token is required when using --silent.', 'red'))
+            return
+        login(args.token)
+    elif args.token:
+        login(args.token)
+    else:
         cprint('Please follow the prompts below to log in using valid GitHub credentials.', 'yellow')
         token = input(colored('? ', 'green') + 'Enter your personal access token: ')
         login(token)
-    else:
-        login(args.token)
     if isAuthenticated():
         print(colored(f'New credentials for {getAuthenticatedUser()} successfully stored.', 'green'))
     else:

--- a/src/LPM.py
+++ b/src/LPM.py
@@ -2,7 +2,7 @@
  * File: LPM.py
  * Copyright (c) 2023 Loupe
  * https://loupe.team
- * 
+ *
  * This file is part of LPM, licensed under the MIT License.
 '''
 '''
@@ -13,7 +13,6 @@ This file contains the command-line interface only. The underlying
 functionality lives in lpm_core.py.
 '''
 
-# Python modules
 import os.path
 import json
 import sys
@@ -29,385 +28,542 @@ with open(version_file, "r") as f:
 
 __author__ = 'Andrew Musser'
 
-# External Modules
 from ASPython import ASTools
 
-# Core LPM functionality. The CLI in this file delegates to functions defined
-# in lpm_core. Importing * preserves the existing call sites in main() that
-# reference these names directly.
+# Core LPM functionality. The CLI delegates to functions defined in lpm_core.
 from lpm_core import *
 
-def main():
 
-    # Extract the name. Probably could just hard-code this to 'LPM'. 
-    prog_base = os.path.basename(sys.argv[0])
-    prog_split = os.path.splitext(prog_base)
-    prog_name = prog_split[0].upper()
+# ---------------------------------------------------------------------------
+# Output coloring helpers.
+# These are configured at the start of main() based on --nocolor, then used
+# by all the cmd_* handlers below.
+# ---------------------------------------------------------------------------
 
-    # Parse arguments from the command line 
-    parser = argparse.ArgumentParser(description='A lightweight wrapper around NPM for Automation Studio dependency management', prog=prog_name)
-    parser.add_argument('cmd', type=str, help='LPM command to execute (init, install, uninstall, list, etc)', default='')
-    parser.add_argument('packages', type=str, nargs='*', help='the packages to be acted upon', default='') 
-    parser.add_argument('-s', '--silent', action='store_true', help='Execute commands silently with default values and no operator prompts')
-    parser.add_argument('-prj', '--asproject', action='store_true', help='Force LPM to treat current directory as AS project')
-    parser.add_argument('-lib', '--aslibrary', action='store_true', help='Force LPM to treat current directory as AS library')
-    parser.add_argument('-src', '--source', action='store_true', help='Use source code for libraries instead of binaries')
-    parser.add_argument('-nc', '--nocolor', action='store_true', help='Dont color the output - to avoid dependency on termcolor')
-    parser.add_argument('-t', '--token', type=str, help='Personal Access Token required for silent login')
-    parser.add_argument('-v', '--version', action='version', version='%(prog)s: ' + __version__)
-    args = parser.parse_args()
+def _identity(text, color):
+    return text
 
-    # Handle output coloring configuration. 
-    if (not args.nocolor):
-        from termcolor import colored, cprint
-    else:
-        # If the colors are skipped, then define dummy versions of termcolor functions. 
-        def colored(text, color):
-            return text
-        def cprint(text, color):
-            print(text)
+def _plain_print(text, color):
+    print(text)
 
-    # Prepend the @loupeteam prefix to all package names, and split any @version suffixes off into separate struct.
+colored = _identity
+cprint = _plain_print
+
+
+# ---------------------------------------------------------------------------
+# Helpers shared between subcommands.
+# ---------------------------------------------------------------------------
+
+# Commands that never require authentication.
+_NO_AUTH = {'login', 'delete', 'status'}
+
+# Commands that may run before `lpm init` has been invoked (i.e. don't require
+# a package.json in the current directory).
+_NO_INIT_REQUIRED = {
+    'login', 'logout', 'delete', 'status',
+    'view', 'info', 'viewall', 'type', 'docs', 'as', 'init',
+}
+
+
+def _normalize_packages(raw_packages):
+    """Prepend the @loupeteam scope and split @version suffixes."""
     packages = []
-    packageVersions = []
-    if(args.packages):   
-        for item in args.packages:
-            # Force package name to lowercase, by convention
-            item = item.lower()
-            # If the @ character is present, it means there's a version specifier.
-            if('@' in item):
-                splitItem = item.split('@')
-                packages.append('@loupeteam/' + splitItem[0])
-                packageVersions.append(splitItem[1])
-            # Othersie, version string is empty.
-            else:
-                packages.append('@loupeteam/' + item)
-                packageVersions.append('')
-
-    # Authenticate with a custom personal access token. 
-    if(args.cmd == 'login'):
-        if not args.silent:
-            cprint('Please follow the prompts below to log in using valid Github credentials.', 'yellow')
-            token = input(colored('? ', 'green') + 'Enter your personal access token: ')
-            login(token)
+    versions = []
+    for item in raw_packages or []:
+        item = item.lower()
+        if '@' in item:
+            name, _, version = item.partition('@')
+            packages.append('@loupeteam/' + name)
+            versions.append(version)
         else:
-            login(args.token)
-        if isAuthenticated():
-            print(colored(f'New credentials for {getAuthenticatedUser()} successfully stored.', 'green'))
-        else:
-            print(colored('Error: invalid credentials. Please try again.', 'red'))
+            packages.append('@loupeteam/' + item)
+            versions.append('')
+    return packages, versions
 
-    # Remove all local files related to LPM.
-    elif(args.cmd == 'delete'):
-        print('Removing LPM content from the local project...')
-        deleteProject()
-        print(colored('All done!', 'green'), 'Thanks for using LPM.')
-        print(colored('Note: LPM-installed content within your AS project folder has not been removed.', 'yellow'))
 
-    # Report on the overall status of LPM. 
-    elif(args.cmd == 'status'):
-        print('Retrieving status...')
-        # Check to see if we're logged in globally. 
-        if(isAuthenticated()):
-            print('-> Logged in: ' + colored('Yes', 'green'))
-            print('-> Current user: ' + colored(getAuthenticatedUser(), 'green'))
-        else:
-            print('-> Logged in: ' + colored('No', 'yellow'))
-        # Check to see if we're initialized with a package.json file.
-        if os.path.exists('package.json'):
-            packageType = getPackageType('.')
-            # Now print out status message based on packageType
-            if(packageType == 'project'):
-                print('-> Local directory status: ' + colored('Initialized with Automation Studio project', 'green'))
-            elif(packageType == 'library'):
-                print('-> Local directory status: ' + colored('Initialized with local library', 'green'))
-            elif((packageType == 'program') | (packageType == 'package')):
-                print('-> Local directory status: ' + colored('Initialized with local program', 'green'))
-            else:
-                print('-> Local directory status: ' + colored('Initialized as stand-alone package manager', 'green'))
-        else:
-            print('-> Local directory status: ' + colored('Not initialized for use with lpm', 'yellow'))
+# ---------------------------------------------------------------------------
+# Subcommand handlers. Each takes the parsed args namespace.
+# ---------------------------------------------------------------------------
 
-    # Check to see if the user is logged in. 
-    elif(not isAuthenticated()):
-        cprint('No credentials found. Please call lpm login before attempting other operations.', 'yellow')
-
-    # Process commands that require authentication. 
+def cmd_login(args):
+    if not args.silent:
+        cprint('Please follow the prompts below to log in using valid Github credentials.', 'yellow')
+        token = input(colored('? ', 'green') + 'Enter your personal access token: ')
+        login(token)
     else:
+        login(args.token)
+    if isAuthenticated():
+        print(colored(f'New credentials for {getAuthenticatedUser()} successfully stored.', 'green'))
+    else:
+        print(colored('Error: invalid credentials. Please try again.', 'red'))
 
-        # Logout of the Github registry.
-        if(args.cmd == 'logout'):
-            print('Logging out...')
-            logout()
-            print(colored('Successfully logged out.', 'green'))
 
-        # View information about a package. 
-        elif(args.cmd == 'view') | (args.cmd == 'info'):
-            if (len(args.packages) > 1):
-                options = args.packages[1:]
-                getInfo(packages[0], options)
-            elif (len(args.packages) > 0):
-                options = []
-                getInfo(packages[0], options)
-            else:
-                print(colored('Please provide the name of one package.', 'yellow'))
+def cmd_logout(args):
+    print('Logging out...')
+    logout()
+    print(colored('Successfully logged out.', 'green'))
 
-        # View a list of all available packages. 
-        elif(args.cmd == 'viewall'):
-            printLoupePackageList()
 
-        # Retrieve the type of a package (or directory). 
-        elif(args.cmd == 'type'):
-            if (len(packages) > 1):
-                print(colored('This command is only supported with a single package.', 'yellow'))
-            else:
-                print(getPackageType(args.packages[0]))
+def cmd_delete(args):
+    print('Removing LPM content from the local project...')
+    deleteProject()
+    print(colored('All done!', 'green'), 'Thanks for using LPM.')
+    print(colored('Note: LPM-installed content within your AS project folder has not been removed.', 'yellow'))
 
-        # Open up documentation page for the library.
-        elif(args.cmd == 'docs'):
-            if (len(packages) > 0):
-                print('Opening up documentation for ' + ', '.join(packages) + '...')
-                openDocumentation(packages)
-                print(colored('Documentation is now up in your browser.', 'green'))
-            else:
-                print(colored('Please provide the name of at least one package.', 'yellow'))
 
-        # Open up the project in Automation Studio. 
-        elif(args.cmd == 'as'):
-            project = ASTools.Project('.')
-            cmd = []
-            print('Opening Automation Studio...')
-            asBin = os.path.join(ASTools.getASPath(project.ASVersion), 'pg.exe')
-            if(not os.path.isfile(asBin)):
-                cprint(f'Project was last opened with {project.ASVersion}, but that version is not installed. Trying to open with AS410 instead...', 'yellow')
-                # If that version isn't installed, try something else. Just hard-coding 410 for now because it's what I have installed!
-                asBin = os.path.join(ASTools.getASPath('AS410'), 'pg.exe')
-            cmd.append(asBin)
-            cmd.append('\"' + os.path.join(os.getcwd(), f'{project.name}.apj') + '\"')
-            executeAndContinue(cmd)
-            time.sleep(3)
-            cprint('Wait for it...', 'yellow')
-            time.sleep(3)
-            cprint('Still working...', 'yellow')
-            time.sleep(3)
-            cprint('Almost done...', 'yellow')
-            time.sleep(3)
-            cprint('Good to go!', 'green')
-
-        # Set up the local directory for package management.
-        elif(args.cmd == 'init'):
-            as_project = False
-            as_library = False
-
-            # Check to see if the current directory is an AS project.
-            try:
-                project = ASTools.Project('.')
-                as_project = True      
-            except:
-                as_project = False
-
-            # Check to see if the current directory is an AS library.
-            try:
-                library = ASTools.Library('.')
-                as_library = True
-            except:
-                as_library = False
-                
-            # Handle AS project.
-            if (as_project) or (args.asproject):
-                print('Automation Studio project found, initializing package manager...')
-                initializeProject()
-                arg_folder = False
-                if(not args.silent):
-                    text = input(colored('? ', 'green') + colored('Would you like to initialize LPM with the existing Loupe libraries in your Automation Studio project?', 'yellow') + ' (y/N) ')
-                    if (text.lower() == 'y') | (text.lower() == 'yes'):
-                        arg_folder = importLibraries()
-                configureProject(args)
-                cprint('Your Automation Studio project is now ready to be used with LPM.', 'green')
-                if (arg_folder):
-                    cprint('Note that you will need to manually remove the _ARG folder to avoid library conflicts.', 'yellow')
-
-            # Handle AS library. 
-            elif (as_library) or (args.aslibrary):
-                # Prepare a library for publication.   
-                name = os.path.basename(os.getcwd())
-                packageData = {}
-                # Check for existing package.json, and extract important info. 
-                if(os.path.exists('package.json')):
-                    print('Found an existing package.json file, extracting its relevant contents...')
-                    packageData = getPackageManifestField('package.json', ['lpm'])
-                print('Creating package.json for the ' + colored(f'{name}', 'yellow') + ' library...')
-                createLibraryManifest(name, packageData)
-                print(colored('The package.json was successfully created.', 'green'))
-
-            else:
-                if(not args.silent):
-                    text = input(colored('? ', 'green') + colored('No Automation Studio project found. Would you like to initialize this directory with a starter AS project?', 'yellow') + ' (Y/n) ')
-                else:
-                    text = 'n'
-                if (text.lower() == 'n') | (text.lower() == 'no'):
-                    initializeProject()
-                    print(colored('This directory has been initialized as a stand-alone package manager.', 'green'))
-                else:
-                    initializeProject()
-                    starterProject = ['@loupeteam/starterasproject49']
-                    installPackages(starterProject, [''])
-                    syncPackages(starterProject)
-                    configureProject(args)
-                    print(colored('Your local directory is now ready to be used with LPM.', 'green'))
-
-        # Require that the init command be run before other commands are allowed. 
-        elif(not os.path.exists('package.json')):
-            cprint('Local directory not initialized. Please run lpm init before attempting other operations.', 'yellow')
-
-        elif(args.cmd == 'configure'):
-            configureProject(args)
-
-        elif(args.cmd == 'debug'):
-            libraries = readLoupeLibraryList()
-            print(libraries)
-
-        # Install one or more packages (and their dependencies).
-        elif(args.cmd == 'install'):
-            # Handle default scenario where sources are not requested (i.e. we're installing binary packages).
-            if (not args.source):
-                if (len(packages) > 0):
-                    print('Installing ' + ', '.join(packages) + '...')
-                    try:
-                        installPackages(packages, packageVersions)
-                    except:
-                        cprint('Error while attempting to install package(s).', 'yellow')
-                        return
-                else:
-                    print('Installing all dependencies...')
-                    try:
-                        installPackages(packages, packageVersions)
-                    except:
-                        cprint('Error while attempting to install package(s).', 'yellow')
-                        return
-                # Move packages from the node_modules folder into the project/main directory. 
-                syncPackages(getAllDependencies(packages))
-            else: # Handle request to install source code instead.
-                if (len(packages) > 0):
-                    print('Attempting to install source for ' + ', '.join(args.packages) + '...')
-
-                sourceDependencies = []
-                for (package, packageVersion) in zip(packages, packageVersions):
-                    installSource(package, packageVersion, sourceDependencies)
-                
-            # Deploy relevant objects to cpu.sw.
-            # First check project-level settings to see if deployment is configured. 
-            deploymentConfigs = getPackageManifestField('package.json', ['lpmConfig', 'deploymentConfigs'])
-            if (deploymentConfigs is not None):
-                print('Deploying ' + ', '.join(packages) + ' to the following configurations: ' + ', '.join(deploymentConfigs))
-                for config in deploymentConfigs:
-                    if(not args.source):
-                        deployPackages(config, getAllDependencies(packages))
-                    else:
-                        # TODO: this split below may not be necessary, TBD.
-                        # For case of source, deploy the source first. 
-                        deployPackages(config, packages)
-                        # Then deploy all of its dependencies.
-                        deployPackages(config, sourceDependencies)
-            cprint('Operation completed successfully.', 'green')
-            for package in packages:
-                packageManifestPath = os.path.join('node_modules', package, 'package.json')
-                if(os.path.exists(packageManifestPath)):
-                    packageType = getPackageManifestField(packageManifestPath, ['lpm', 'type'])
-                    if(packageType == 'project'):
-                        return
-            if (deploymentConfigs is None):
-                cprint("Note that the installed packages have not been deployed.", "yellow")
-                cprint("You will need to do this manually, or you can configure deployment targets with the 'lpm configure' command.", 'yellow')
-
-        # Uninstall one or more packages.
-        elif(args.cmd == 'uninstall'):
-            if (len(packages) > 0):
-                print('Uninstalling ' + ', '.join(packages) + '...')
-                try:
-                    uninstallPackages(packages)
-                except:
-                    cprint('Error while attempting to uninstall package(s).', 'yellow')
-                    return
-                syncPackages(getAllDependencies(packages))
-                cprint('Operation completed successfully.', 'green')
-            else:
-                print(colored('Please provide the name of at least one package.', 'yellow'))
-
-        # Open git client for a specific source library.
-        elif(args.cmd == 'git'):
-            # Retrieve configured Git client.
-            gitClient = getPackageManifestField('package.json', ['lpmConfig', 'gitClient'])
-            if(gitClient == ''):
-                cprint("No Git client configured (please run lpm configure)", "yellow")
-            elif gitClient != 'GitExtensions':
-                cprint(f"We don't support {gitClient}, are you kidding?", "yellow")
-            else:
-                # GitExtensions is configured git client                
-                sourceInfoFilePath = os.path.join(".", "TempObjects", "sourceInfo.json")
-                sourceInfo = getJsonData(sourceInfoFilePath)
-                print(f'Opening {gitClient} for these packages: ' + ', '.join(args.packages))
-                for package in packages:
-                    repoPath = sourceInfo.get(package, {}).get("repoPath", None)
-                    if repoPath is not None:
-                        cmd = []
-                        cmd.append('gitex.cmd')
-                        cmd.append('openrepo')
-                        cmd.append('\"' + os.path.join(os.getcwd(), repoPath) + '\"')
-                        executeAndContinue(cmd)
-                    else:
-                        cprint(f"Could not find repo location for {package}. Verify that it is installed as source.", "yellow")
-
-        # Publish a binary library.
-        elif(args.cmd == 'publish'):
-            # Introspect the package.json to verify that the package name has the right scope prefix (i.e. @loupeteam). 
-            data = getPackageManifestData('package.json')
-            if data['name'].find('@loupeteam') != 0:
-                cprint('Error: the package name must include the @loupeteam scope prefix.', 'yellow')
-            else:
-                try:
-                    # Introspect the package.json to verify that the 'repository' field is present. 
-                    repoUrl = data['repository']['url'] # This triggers an exception if it doesn't exist
-                    if (args.silent):
-                        text = 'y'
-                    else:
-                        text = input(colored('? ', 'green') + 'Are you sure you want to publish ' + colored(data['name'], 'yellow') + ' version ' + colored(data['version'], 'yellow') + '? (y/N) ')
-                    if (text.lower() == 'y') | (text.lower() == 'yes'):
-                        try: 
-                            # Clean up the local directory before publishing.
-                            # If there's a Jenkinsfile present, remove it.
-                            if(os.path.isfile('./Jenkinsfile')):
-                               os.remove('./Jenkinsfile') 
-                            # Publish the package.
-                            execute(['npm' ,'publish'], True)
-                            cprint('Successfully published ' + data['name'] + ' version ' + data['version'] + '.', 'green')
-                        except:
-                            cprint("Error while publishing. Please check the detailed error message above.", 'yellow')                       
-                except:
-                    cprint('Error: the package.json file must include a repository parameter', 'yellow')
-                    cprint('For example:', 'yellow')
-                    print('"repository": {')
-                    print('    "type": "git",')
-                    print('    "url": "https://github.com/loupeteam/piper"')
-                    print('}')  
-
-        # Fetch the list of all dependencies for the root level, or one of its direct package dependencies. 
-        elif((args.cmd == 'list') and (len(args.packages) == 0)):
-            cmd = []
-            cmd.append('npm list')
-            cmd.append('-all')
-            executeStandard(cmd)
-
-        # In all other cases, just pass the command and list of packages straight through to NPM.
+def cmd_status(args):
+    print('Retrieving status...')
+    if isAuthenticated():
+        print('-> Logged in: ' + colored('Yes', 'green'))
+        print('-> Current user: ' + colored(getAuthenticatedUser(), 'green'))
+    else:
+        print('-> Logged in: ' + colored('No', 'yellow'))
+    if os.path.exists('package.json'):
+        packageType = getPackageType('.')
+        if packageType == 'project':
+            print('-> Local directory status: ' + colored('Initialized with Automation Studio project', 'green'))
+        elif packageType == 'library':
+            print('-> Local directory status: ' + colored('Initialized with local library', 'green'))
+        elif packageType in ('program', 'package'):
+            print('-> Local directory status: ' + colored('Initialized with local program', 'green'))
         else:
-            runGenericNpmCmd(args.cmd, packages)
-            cprint('Operation completed', 'green')
+            print('-> Local directory status: ' + colored('Initialized as stand-alone package manager', 'green'))
+    else:
+        print('-> Local directory status: ' + colored('Not initialized for use with lpm', 'yellow'))
 
-    return
+
+def cmd_view(args):
+    packages, _ = _normalize_packages(args.packages)
+    if len(args.packages) > 1:
+        getInfo(packages[0], args.packages[1:])
+    elif len(args.packages) == 1:
+        getInfo(packages[0], [])
+    else:
+        print(colored('Please provide the name of one package.', 'yellow'))
+
+
+def cmd_viewall(args):
+    printLoupePackageList()
+
+
+def cmd_type(args):
+    if len(args.packages) > 1:
+        print(colored('This command is only supported with a single package.', 'yellow'))
+    elif len(args.packages) == 1:
+        print(getPackageType(args.packages[0]))
+    else:
+        print(colored('Please provide the name of one package.', 'yellow'))
+
+
+def cmd_docs(args):
+    packages, _ = _normalize_packages(args.packages)
+    if packages:
+        print('Opening up documentation for ' + ', '.join(packages) + '...')
+        openDocumentation(packages)
+        print(colored('Documentation is now up in your browser.', 'green'))
+    else:
+        print(colored('Please provide the name of at least one package.', 'yellow'))
+
+
+def cmd_as(args):
+    project = ASTools.Project('.')
+    print('Opening Automation Studio...')
+    asBin = os.path.join(ASTools.getASPath(project.ASVersion), 'pg.exe')
+    if not os.path.isfile(asBin):
+        cprint(f'Project was last opened with {project.ASVersion}, but that version is not installed. Trying to open with AS410 instead...', 'yellow')
+        # If that version isn't installed, try something else. Just hard-coding 410 for now because it's what I have installed!
+        asBin = os.path.join(ASTools.getASPath('AS410'), 'pg.exe')
+    cmd = [asBin, '\"' + os.path.join(os.getcwd(), f'{project.name}.apj') + '\"']
+    executeAndContinue(cmd)
+    time.sleep(3)
+    cprint('Wait for it...', 'yellow')
+    time.sleep(3)
+    cprint('Still working...', 'yellow')
+    time.sleep(3)
+    cprint('Almost done...', 'yellow')
+    time.sleep(3)
+    cprint('Good to go!', 'green')
+
+
+def cmd_init(args):
+    as_project = False
+    as_library = False
+    try:
+        ASTools.Project('.')
+        as_project = True
+    except:
+        as_project = False
+    try:
+        ASTools.Library('.')
+        as_library = True
+    except:
+        as_library = False
+
+    if as_project or args.asproject:
+        print('Automation Studio project found, initializing package manager...')
+        initializeProject()
+        arg_folder = False
+        if not args.silent:
+            text = input(colored('? ', 'green') + colored('Would you like to initialize LPM with the existing Loupe libraries in your Automation Studio project?', 'yellow') + ' (y/N) ')
+            if text.lower() in ('y', 'yes'):
+                arg_folder = importLibraries()
+        configureProject(args)
+        cprint('Your Automation Studio project is now ready to be used with LPM.', 'green')
+        if arg_folder:
+            cprint('Note that you will need to manually remove the _ARG folder to avoid library conflicts.', 'yellow')
+
+    elif as_library or args.aslibrary:
+        name = os.path.basename(os.getcwd())
+        packageData = {}
+        if os.path.exists('package.json'):
+            print('Found an existing package.json file, extracting its relevant contents...')
+            packageData = getPackageManifestField('package.json', ['lpm'])
+        print('Creating package.json for the ' + colored(f'{name}', 'yellow') + ' library...')
+        createLibraryManifest(name, packageData)
+        print(colored('The package.json was successfully created.', 'green'))
+
+    else:
+        if not args.silent:
+            text = input(colored('? ', 'green') + colored('No Automation Studio project found. Would you like to initialize this directory with a starter AS project?', 'yellow') + ' (Y/n) ')
+        else:
+            text = 'n'
+        if text.lower() in ('n', 'no'):
+            initializeProject()
+            print(colored('This directory has been initialized as a stand-alone package manager.', 'green'))
+        else:
+            initializeProject()
+            starterProject = ['@loupeteam/starterasproject49']
+            installPackages(starterProject, [''])
+            syncPackages(starterProject)
+            configureProject(args)
+            print(colored('Your local directory is now ready to be used with LPM.', 'green'))
+
+
+def cmd_configure(args):
+    configureProject(args)
+
+
+def cmd_debug(args):
+    libraries = readLoupeLibraryList()
+    print(libraries)
+
+
+def cmd_install(args):
+    packages, packageVersions = _normalize_packages(args.packages)
+
+    if not args.source:
+        if packages:
+            print('Installing ' + ', '.join(packages) + '...')
+        else:
+            print('Installing all dependencies...')
+        try:
+            installPackages(packages, packageVersions)
+        except:
+            cprint('Error while attempting to install package(s).', 'yellow')
+            return
+        # Move packages from the node_modules folder into the project/main directory.
+        syncPackages(getAllDependencies(packages))
+        sourceDependencies = []
+    else:
+        if packages:
+            print('Attempting to install source for ' + ', '.join(args.packages) + '...')
+        sourceDependencies = []
+        for (package, packageVersion) in zip(packages, packageVersions):
+            installSource(package, packageVersion, sourceDependencies)
+
+    # Deploy relevant objects to cpu.sw.
+    deploymentConfigs = getPackageManifestField('package.json', ['lpmConfig', 'deploymentConfigs'])
+    if deploymentConfigs is not None:
+        print('Deploying ' + ', '.join(packages) + ' to the following configurations: ' + ', '.join(deploymentConfigs))
+        for config in deploymentConfigs:
+            if not args.source:
+                deployPackages(config, getAllDependencies(packages))
+            else:
+                # TODO: this split below may not be necessary, TBD.
+                # For case of source, deploy the source first.
+                deployPackages(config, packages)
+                # Then deploy all of its dependencies.
+                deployPackages(config, sourceDependencies)
+    cprint('Operation completed successfully.', 'green')
+    for package in packages:
+        packageManifestPath = os.path.join('node_modules', package, 'package.json')
+        if os.path.exists(packageManifestPath):
+            packageType = getPackageManifestField(packageManifestPath, ['lpm', 'type'])
+            if packageType == 'project':
+                return
+    if deploymentConfigs is None:
+        cprint("Note that the installed packages have not been deployed.", "yellow")
+        cprint("You will need to do this manually, or you can configure deployment targets with the 'lpm configure' command.", 'yellow')
+
+
+def cmd_uninstall(args):
+    packages, _ = _normalize_packages(args.packages)
+    if not packages:
+        print(colored('Please provide the name of at least one package.', 'yellow'))
+        return
+    print('Uninstalling ' + ', '.join(packages) + '...')
+    try:
+        uninstallPackages(packages)
+    except:
+        cprint('Error while attempting to uninstall package(s).', 'yellow')
+        return
+    syncPackages(getAllDependencies(packages))
+    cprint('Operation completed successfully.', 'green')
+
+
+def cmd_git(args):
+    packages, _ = _normalize_packages(args.packages)
+    gitClient = getPackageManifestField('package.json', ['lpmConfig', 'gitClient'])
+    if gitClient == '':
+        cprint("No Git client configured (please run lpm configure)", "yellow")
+        return
+    if gitClient != 'GitExtensions':
+        cprint(f"We don't support {gitClient}, are you kidding?", "yellow")
+        return
+    sourceInfoFilePath = os.path.join(".", "TempObjects", "sourceInfo.json")
+    sourceInfo = getJsonData(sourceInfoFilePath)
+    print(f'Opening {gitClient} for these packages: ' + ', '.join(args.packages))
+    for package in packages:
+        repoPath = sourceInfo.get(package, {}).get("repoPath", None)
+        if repoPath is not None:
+            cmd = ['gitex.cmd', 'openrepo', '\"' + os.path.join(os.getcwd(), repoPath) + '\"']
+            executeAndContinue(cmd)
+        else:
+            cprint(f"Could not find repo location for {package}. Verify that it is installed as source.", "yellow")
+
+
+def cmd_publish(args):
+    data = getPackageManifestData('package.json')
+    if data['name'].find('@loupeteam') != 0:
+        cprint('Error: the package name must include the @loupeteam scope prefix.', 'yellow')
+        return
+    try:
+        repoUrl = data['repository']['url']  # triggers an exception if missing
+    except:
+        cprint('Error: the package.json file must include a repository parameter', 'yellow')
+        cprint('For example:', 'yellow')
+        print('"repository": {')
+        print('    "type": "git",')
+        print('    "url": "https://github.com/loupeteam/piper"')
+        print('}')
+        return
+    if args.silent:
+        text = 'y'
+    else:
+        text = input(colored('? ', 'green') + 'Are you sure you want to publish ' + colored(data['name'], 'yellow') + ' version ' + colored(data['version'], 'yellow') + '? (y/N) ')
+    if text.lower() not in ('y', 'yes'):
+        return
+    try:
+        # Clean up the local directory before publishing.
+        if os.path.isfile('./Jenkinsfile'):
+            os.remove('./Jenkinsfile')
+        execute(['npm', 'publish'], True)
+        cprint('Successfully published ' + data['name'] + ' version ' + data['version'] + '.', 'green')
+    except:
+        cprint("Error while publishing. Please check the detailed error message above.", 'yellow')
+
+
+def cmd_list(args):
+    if args.packages:
+        # Defer to npm with the supplied packages.
+        runGenericNpmCmd('list', args.packages)
+        cprint('Operation completed', 'green')
+        return
+    executeStandard(['npm list', '-all'])
+
+
+def cmd_npm_passthrough(args):
+    """Fallback for any command not recognized as an LPM subcommand."""
+    packages, _ = _normalize_packages(args.packages)
+    runGenericNpmCmd(args.cmd, packages)
+    cprint('Operation completed', 'green')
+
+
+# ---------------------------------------------------------------------------
+# Argument parser construction.
+# ---------------------------------------------------------------------------
+
+def _build_parser(prog_name):
+    parser = argparse.ArgumentParser(
+        description='A lightweight wrapper around NPM for Automation Studio dependency management',
+        prog=prog_name,
+    )
+    # Global flags (apply to all subcommands).
+    parser.add_argument('-s', '--silent', action='store_true',
+                        help='Execute commands silently with default values and no operator prompts')
+    parser.add_argument('-nc', '--nocolor', action='store_true',
+                        help='Dont color the output - to avoid dependency on termcolor')
+    parser.add_argument('-v', '--version', action='version', version='%(prog)s: ' + __version__)
+
+    sub = parser.add_subparsers(dest='cmd', metavar='command')
+
+    # login
+    p = sub.add_parser('login', help='Authenticate with the GitHub package registry')
+    p.add_argument('-t', '--token', type=str, help='Personal Access Token required for silent login')
+    p.set_defaults(func=cmd_login)
+
+    # logout
+    p = sub.add_parser('logout', help='Log out of the GitHub package registry')
+    p.set_defaults(func=cmd_logout)
+
+    # delete
+    p = sub.add_parser('delete', help='Remove all local LPM files (package.json, .npmrc, node_modules)')
+    p.set_defaults(func=cmd_delete)
+
+    # status
+    p = sub.add_parser('status', help='Show authentication and initialization status')
+    p.set_defaults(func=cmd_status)
+
+    # view / info
+    for name in ('view', 'info'):
+        p = sub.add_parser(name, help='View information about a package')
+        p.add_argument('packages', nargs='*', help='Package and optional npm view fields')
+        p.set_defaults(func=cmd_view)
+
+    # viewall
+    p = sub.add_parser('viewall', help='List all available Loupe packages')
+    p.set_defaults(func=cmd_viewall)
+
+    # type
+    p = sub.add_parser('type', help='Print the LPM type of a package or directory')
+    p.add_argument('packages', nargs='*')
+    p.set_defaults(func=cmd_type)
+
+    # docs
+    p = sub.add_parser('docs', help='Open the documentation page for one or more packages')
+    p.add_argument('packages', nargs='*')
+    p.set_defaults(func=cmd_docs)
+
+    # as
+    p = sub.add_parser('as', help='Open the project in Automation Studio')
+    p.set_defaults(func=cmd_as)
+
+    # init
+    p = sub.add_parser('init', help='Initialize the current directory for use with LPM')
+    p.add_argument('-prj', '--asproject', action='store_true',
+                   help='Force LPM to treat current directory as AS project')
+    p.add_argument('-lib', '--aslibrary', action='store_true',
+                   help='Force LPM to treat current directory as AS library')
+    p.set_defaults(func=cmd_init)
+
+    # configure
+    p = sub.add_parser('configure', help='Configure deployment targets and Git client')
+    p.set_defaults(func=cmd_configure)
+
+    # debug
+    p = sub.add_parser('debug', help='Print the list of installed Loupe libraries')
+    p.set_defaults(func=cmd_debug)
+
+    # install
+    p = sub.add_parser('install', help='Install one or more packages')
+    p.add_argument('packages', nargs='*')
+    p.add_argument('-src', '--source', action='store_true',
+                   help='Use source code for libraries instead of binaries')
+    p.set_defaults(func=cmd_install)
+
+    # uninstall
+    p = sub.add_parser('uninstall', help='Uninstall one or more packages')
+    p.add_argument('packages', nargs='*')
+    p.set_defaults(func=cmd_uninstall)
+
+    # git
+    p = sub.add_parser('git', help='Open the configured Git client for source-installed packages')
+    p.add_argument('packages', nargs='*')
+    p.set_defaults(func=cmd_git)
+
+    # publish
+    p = sub.add_parser('publish', help='Publish a binary library to the GitHub package registry')
+    p.set_defaults(func=cmd_publish)
+
+    # list
+    p = sub.add_parser('list', help='List installed dependencies')
+    p.add_argument('packages', nargs='*')
+    p.set_defaults(func=cmd_list)
+
+    return parser, sub
+
+
+def _is_known_command(parser, sub, argv):
+    """Return True if argv contains a recognized subcommand.
+
+    Walks past leading global flags to find the first positional, then checks
+    it against the registered subparsers. This lets us preserve the legacy
+    behavior where unknown commands are passed through to npm.
+    """
+    known = set(sub.choices.keys())
+    # Flags that take a value at the top level. Currently none do (--silent
+    # and --nocolor are store_true), but keep the structure in case that
+    # changes.
+    value_flags = set()
+    i = 0
+    while i < len(argv):
+        token = argv[i]
+        if token in ('-h', '--help', '-v', '--version'):
+            return True  # let argparse handle it
+        if token in value_flags:
+            i += 2
+            continue
+        if token.startswith('-'):
+            i += 1
+            continue
+        return token in known
+    return False  # no command at all → let argparse error
+
+
+# ---------------------------------------------------------------------------
+# Entry point.
+# ---------------------------------------------------------------------------
+
+def main():
+    global colored, cprint
+
+    prog_base = os.path.basename(sys.argv[0])
+    prog_name = os.path.splitext(prog_base)[0].upper()
+
+    parser, sub = _build_parser(prog_name)
+
+    raw_args = sys.argv[1:]
+
+    # Legacy behavior: any unrecognized first command is forwarded to npm.
+    if raw_args and not _is_known_command(parser, sub, raw_args):
+        fallback = argparse.ArgumentParser(add_help=False)
+        fallback.add_argument('-s', '--silent', action='store_true')
+        fallback.add_argument('-nc', '--nocolor', action='store_true')
+        ns, leftover = fallback.parse_known_args(raw_args)
+        ns.cmd = leftover[0] if leftover else ''
+        ns.packages = leftover[1:]
+        ns.func = cmd_npm_passthrough  # type: ignore[attr-defined]
+    else:
+        ns = parser.parse_args()
+
+    # Configure output coloring now that --nocolor is known.
+    if not ns.nocolor:
+        from termcolor import colored as _colored, cprint as _cprint
+        colored = _colored
+        cprint = _cprint
+    else:
+        colored = _identity
+        cprint = _plain_print
+
+    # If no command was given, show help and exit.
+    if not getattr(ns, 'cmd', None):
+        parser.print_help()
+        return
+
+    # Auth gate.
+    if ns.cmd not in _NO_AUTH and not isAuthenticated():
+        cprint('No credentials found. Please call lpm login before attempting other operations.', 'yellow')
+        return
+
+    # Init gate (commands beyond this point operate on a configured directory).
+    if ns.cmd not in _NO_INIT_REQUIRED and not os.path.exists('package.json'):
+        cprint('Local directory not initialized. Please run lpm init before attempting other operations.', 'yellow')
+        return
+
+    ns.func(ns)
 
 
 if __name__ == "__main__":
-    
     # Configure colored logger
     logging.basicConfig(stream=sys.stderr, level=logging.INFO)
     kernel32 = ctypes.windll.kernel32

--- a/src/LPM.py
+++ b/src/LPM.py
@@ -55,7 +55,7 @@ cprint = _plain_print
 # ---------------------------------------------------------------------------
 
 # Commands that never require authentication.
-_NO_AUTH = {'login', 'delete', 'status'}
+_NO_AUTH = {'login', 'logout', 'delete', 'status'}
 
 # Commands that may run before `lpm init` has been invoked (i.e. don't require
 # a package.json in the current directory).


### PR DESCRIPTION
## Summary

Refactors `src/LPM.py` to use `argparse` subparsers instead of a single positional `cmd` argument followed by a 30+ branch if/elif chain.

## Changes

- Each subcommand (`login`, `logout`, `delete`, `status`, `view`/`info`, `viewall`, `type`, `docs`, `as`, `init`, `configure`, `debug`, `install`, `uninstall`, `git`, `publish`, `list`) is its own `add_parser` with its own help text.
- Per-command flags are scoped to where they belong:
  - `-src/--source` only on `install`
  - `-t/--token` only on `login`
  - `-prj/--asproject` and `-lib/--aslibrary` only on `init`
- Global flags (`-s/--silent`, `-nc/--nocolor`, `-v/--version`) remain on the top-level parser.
- Each command body extracted into a `cmd_*` handler dispatched via `args.func(args)`.
- Auth gate and init gate refactored into named sets (`_NO_AUTH`, `_NO_INIT_REQUIRED`).
- Unknown commands continue to be forwarded to npm (legacy passthrough behavior preserved).

## Validation

- `python -m py_compile` clean
- All 6 LPM CLI tests pass (the 2 build tests are environment-dependent and unaffected)
- Inno Setup build succeeds
- `python src/LPM.py --help` and per-command `--help` output verified