### PR TITLE
fix: sync and deploy all deps when lpm install is run with no args

### DIFF
--- a/src/LPM.py
+++ b/src/LPM.py
@@ -266,6 +266,11 @@ def cmd_install(args):
         except:
             cprint('Error while attempting to install package(s).', 'yellow')
             return
+        # If no explicit packages were given, resolve the full list from the
+        # local package.json so that sync and deploy still run.
+        if not packages:
+            deps = getPackageManifestField('package.json', ['dependencies']) or {}
+            packages = list(deps.keys())
         # Move packages from the node_modules folder into the project/main directory.
         syncPackages(getAllDependencies(packages))
         sourceDependencies = []

--- a/test/test_lpm.py
+++ b/test/test_lpm.py
@@ -201,6 +201,38 @@ class TestLpm:
         finally:
             monkeypatch.undo()
 
+    def test_install_no_args_syncs_and_deploys(self, monkeypatch):
+        """Regression: lpm install with no args should sync and deploy all declared dependencies."""
+        monkeypatch.chdir(self.test_dir)
+        try:
+            # Pre-condition: package.json must already have dependencies (added by prior install tests).
+            with open("package.json") as p:
+                package_dict = json.load(p)
+            deps = package_dict.get("dependencies", {})
+            assert deps, "Pre-condition: package.json must have dependencies"
+
+            from unittest.mock import patch
+
+            with patch("LPM.installPackages"), \
+                 patch("LPM.getAllDependencies", return_value=list(deps.keys())) as mock_get_all_deps, \
+                 patch("LPM.syncPackages") as mock_sync, \
+                 patch("LPM.deployPackages") as mock_deploy:
+                monkeypatch.setattr(sys, "argv", ["lpm.py", "install"])
+                LPM.main()
+
+            # getAllDependencies must have been called with the resolved package list,
+            # not an empty list (which would make sync/deploy a no-op – the original bug).
+            assert mock_get_all_deps.called, "getAllDependencies was not called"
+            call_packages = mock_get_all_deps.call_args_list[0][0][0]
+            assert len(call_packages) > 0, (
+                "getAllDependencies was called with an empty list; "
+                "sync/deploy would be a no-op (regression of the no-args install bug)"
+            )
+            assert mock_sync.called, "syncPackages was not called"
+            assert mock_deploy.called, "deployPackages was not called"
+        finally:
+            monkeypatch.undo()
+
     def test_build_intel(self, monkeypatch):
         monkeypatch.chdir(self.test_dir)
         try:


### PR DESCRIPTION
## Problem

When running `lpm install` with no package arguments, npm correctly downloads all dependencies listed in `package.json`, but nothing was synced to the AS project or deployed to the CPU configuration.

**Root cause:** After `npm install` completes, `syncPackages` and `deployPackages` were called with the original (empty) `packages` list. `getAllDependencies([])` returns `[]`, making both calls no-ops.

## Fix

After `npm install`, if no packages were explicitly requested, resolve the full dependency list from the local `package.json` before calling sync and deploy.

```python
if not packages:
    deps = getPackageManifestField('package.json', ['dependencies']) or {}
    packages = list(deps.keys())
```

This ensures `lpm install` (no args) behaves the same as `lpm install foo bar` for the sync/deploy phase.