### PR TITLE
Update release to publish as a npm package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,24 +27,24 @@ jobs:
           registry-url: 'https://npm.pkg.github.com'
           scope: '@loupeteam'
 
-      - name: Sync version from tag
+      - name: Validate versions match tag
         shell: bash
         run: |
-          version="${{ github.ref_name }}"
-          version="${version#v}"
-          npm version "$version" --no-git-tag-version --allow-same-version
-          python3 <<'PY'
-          import json
-          import os
-          version = os.environ['VERSION'].lstrip('v')
-          with open('src/version.json', 'r') as f:
-              data = json.load(f)
-          data['version'] = version
-          with open('src/version.json', 'w') as f:
-              json.dump(data, f, indent=4)
-          PY
-        env:
-          VERSION: ${{ github.ref_name }}
+          tag_version="${{ github.ref_name }}"
+          tag_version="${tag_version#v}"
+          pkg_version=$(node -p "require('./package.json').version")
+          src_version=$(python3 -c "import json; print(json.load(open('src/version.json'))['version'])")
+          if [ "$pkg_version" != "$tag_version" ]; then
+            echo "ERROR: package.json version ($pkg_version) does not match tag ($tag_version)."
+            echo "Bump the version in package.json and src/version.json before tagging."
+            exit 1
+          fi
+          if [ "$src_version" != "$tag_version" ]; then
+            echo "ERROR: src/version.json version ($src_version) does not match tag ($tag_version)."
+            echo "Bump the version in package.json and src/version.json before tagging."
+            exit 1
+          fi
+          echo "Version check passed: $tag_version"
 
       - name: Publish to GitHub Packages
         run: npm publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,15 +20,6 @@ jobs:
         with:
           submodules: true
 
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ github.ref_name }}
-          name: ${{ github.ref_name }}
-          generate_release_notes: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Set up Node.js for GitHub Packages
         uses: actions/setup-node@v4
         with:
@@ -42,19 +33,32 @@ jobs:
           version="${{ github.ref_name }}"
           version="${version#v}"
           npm version "$version" --no-git-tag-version --allow-same-version
-          python3 -c "
+          python3 <<'PY'
           import json
+          import os
+          version = os.environ['VERSION'].lstrip('v')
           with open('src/version.json', 'r') as f:
               data = json.load(f)
-          data['version'] = '$version'
+          data['version'] = version
           with open('src/version.json', 'w') as f:
               json.dump(data, f, indent=4)
-          "
+          PY
+        env:
+          VERSION: ${{ github.ref_name }}
 
       - name: Publish to GitHub Packages
         run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # TEMPORARILY DISABLED: Code signing certificate is not currently working.
   # Re-enable this job (windows-2022 runner required) once resolved.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,10 +6,14 @@ on:
     tags:
       - v*
 
+permissions:
+  contents: write
+  packages: write
+
 jobs:
   release-installer:
     runs-on: windows-2022
-    timeout-minutes: 3
+    timeout-minutes: 10
     env:
       SM_API_KEY: ${{ secrets.SM_API_KEY }}
       SM_CLIENT_CERT_FILE: "D:\\Certificate_pkcs12.p12"
@@ -21,49 +25,78 @@ jobs:
         with:
           submodules: true
 
-      - name: Download Inno Setup installer
-        run: Invoke-WebRequest -Uri "https://jrsoftware.org/download.php/is.exe" -OutFile "is.exe"
-      - name: Install Inno Setup silently
-        run: .\is.exe /verysilent /dir="C:\Program Files\InnoSetup"
+      # TEMPORARILY DISABLED: Code signing certificate is not currently working.
+      # Re-enable the EXE build, signing, and S3 upload steps once resolved.
+      # - name: Download Inno Setup installer
+      #   run: Invoke-WebRequest -Uri "https://jrsoftware.org/download.php/is.exe" -OutFile "is.exe"
+      # - name: Install Inno Setup silently
+      #   run: .\is.exe /verysilent /dir="C:\Program Files\InnoSetup"
+      #
+      # - name: Create the EXE Installer
+      #   working-directory: ./utils
+      #   run: ./BuildInstaller.bat
+      #
+      # - name: Code Signing Setup - Setup Certificate
+      #   shell: bash
+      #   run: echo "${{secrets.SM_CLIENT_CERT_FILE_B64 }}" | base64 --decode > /d/Certificate_pkcs12.p12
+      #
+      # - name: Code Signing Setup - add to path
+      #   shell: bash
+      #   run: |
+      #     echo "C:\Program Files (x86)\Windows Kits\10\App Certification Kit" >> $GITHUB_PATH
+      #     echo "C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools" >> $GITHUB_PATH
+      #     echo "C:\Program Files\DigiCert\DigiCert One Signing Manager Tools" >> $GITHUB_PATH
+      #
+      # - name: Code Signing Setup - Setup SSM KSP on windows latest
+      #   shell: cmd
+      #   run: |
+      #     curl -X GET https://one.digicert.com/signingmanager/api-ui/v1/releases/smtools-windows-x64.msi/download -H "x-api-key:%SM_API_KEY%" -o smtools-windows-x64.msi
+      #     msiexec /i smtools-windows-x64.msi /quiet /qn
+      #     smksp_registrar.exe list
+      #     smctl.exe keypair ls
+      #     C:\Windows\System32\certutil.exe -csp "DigiCert Signing Manager KSP" -key -user
+      #     smksp_cert_sync.exe
+      #
+      # - name: Code Signing Setup - Sign using Signtool
+      #   run: |
+      #     signtool.exe sign /sha1 ${{ secrets.SM_CODE_SIGNING_CERT_SHA1_HASH }} /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 "./build/LPM-Setup.exe"
+      #     signtool.exe verify /v /pa "./build/LPM-Setup.exe"
+      #
+      # - name: Configure AWS Credentials
+      #   uses: aws-actions/configure-aws-credentials@v4.0.2
+      #   with:
+      #     aws-region: us-west-2
+      #     aws-access-key-id: ${{ secrets.LPM_S3_ACCESS_KEY_ID }}
+      #     aws-secret-access-key: ${{ secrets.LPM_S3_SECRET_ACCESS_KEY }}
+      #
+      # - name: Upload Installer to S3
+      #   run: |
+      #     aws s3 cp ./build/LPM-Setup.exe s3://loupe-lpm-assets/releases/latest/LPM-Setup.exe
+      #     aws s3 cp ./build/LPM-Setup.exe s3://loupe-lpm-assets/releases/${{ github.ref_name }}/LPM-Setup.exe
 
-      - name: Create the EXE Installer
-        working-directory: ./utils
-        run: ./BuildInstaller.bat
-
-      - name: Code Signing Setup - Setup Certificate
-        shell: bash
-        run: echo "${{secrets.SM_CLIENT_CERT_FILE_B64 }}" | base64 --decode > /d/Certificate_pkcs12.p12
-
-      - name: Code Signing Setup - add to path
-        shell: bash
-        run: |
-          echo "C:\Program Files (x86)\Windows Kits\10\App Certification Kit" >> $GITHUB_PATH
-          echo "C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools" >> $GITHUB_PATH
-          echo "C:\Program Files\DigiCert\DigiCert One Signing Manager Tools" >> $GITHUB_PATH
-
-      - name: Code Signing Setup - Setup SSM KSP on windows latest
-        shell: cmd
-        run: |
-          curl -X GET https://one.digicert.com/signingmanager/api-ui/v1/releases/smtools-windows-x64.msi/download -H "x-api-key:%SM_API_KEY%" -o smtools-windows-x64.msi
-          msiexec /i smtools-windows-x64.msi /quiet /qn
-          smksp_registrar.exe list
-          smctl.exe keypair ls
-          C:\Windows\System32\certutil.exe -csp "DigiCert Signing Manager KSP" -key -user
-          smksp_cert_sync.exe
-
-      - name: Code Signing Setup - Sign using Signtool
-        run: |
-          signtool.exe sign /sha1 ${{ secrets.SM_CODE_SIGNING_CERT_SHA1_HASH }} /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 "./build/LPM-Setup.exe"
-          signtool.exe verify /v /pa "./build/LPM-Setup.exe"
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4.0.2
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
         with:
-          aws-region: us-west-2
-          aws-access-key-id: ${{ secrets.LPM_S3_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.LPM_S3_SECRET_ACCESS_KEY }}
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Upload Installer to S3
+      - name: Set up Node.js for GitHub Packages
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@loupeteam'
+
+      - name: Sync package.json version with tag
+        shell: pwsh
         run: |
-          aws s3 cp ./build/LPM-Setup.exe s3://loupe-lpm-assets/releases/latest/LPM-Setup.exe
-          aws s3 cp ./build/LPM-Setup.exe s3://loupe-lpm-assets/releases/${{ github.ref_name }}/LPM-Setup.exe
+          $version = "${{ github.ref_name }}" -replace '^v',''
+          npm version $version --no-git-tag-version --allow-same-version
+
+      - name: Publish to GitHub Packages
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
-name: LPM Installer Publish
-run-name: Publish LPM Installer ${{ github.ref_name }}
+name: LPM Release
+run-name: LPM Release ${{ github.ref_name }}
 
 on:
   push:
@@ -11,68 +11,14 @@ permissions:
   packages: write
 
 jobs:
-  release-installer:
-    runs-on: windows-2022
+  release:
+    runs-on: ubuntu-latest
     timeout-minutes: 10
-    env:
-      SM_API_KEY: ${{ secrets.SM_API_KEY }}
-      SM_CLIENT_CERT_FILE: "D:\\Certificate_pkcs12.p12"
-      SM_CLIENT_CERT_PASSWORD: ${{ secrets.SM_CLIENT_CERT_PASSWORD }}
-      SM_HOST: ${{ secrets.SM_HOST }}
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
         with:
           submodules: true
-
-      # TEMPORARILY DISABLED: Code signing certificate is not currently working.
-      # Re-enable the EXE build, signing, and S3 upload steps once resolved.
-      # - name: Download Inno Setup installer
-      #   run: Invoke-WebRequest -Uri "https://jrsoftware.org/download.php/is.exe" -OutFile "is.exe"
-      # - name: Install Inno Setup silently
-      #   run: .\is.exe /verysilent /dir="C:\Program Files\InnoSetup"
-      #
-      # - name: Create the EXE Installer
-      #   working-directory: ./utils
-      #   run: ./BuildInstaller.bat
-      #
-      # - name: Code Signing Setup - Setup Certificate
-      #   shell: bash
-      #   run: echo "${{secrets.SM_CLIENT_CERT_FILE_B64 }}" | base64 --decode > /d/Certificate_pkcs12.p12
-      #
-      # - name: Code Signing Setup - add to path
-      #   shell: bash
-      #   run: |
-      #     echo "C:\Program Files (x86)\Windows Kits\10\App Certification Kit" >> $GITHUB_PATH
-      #     echo "C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools" >> $GITHUB_PATH
-      #     echo "C:\Program Files\DigiCert\DigiCert One Signing Manager Tools" >> $GITHUB_PATH
-      #
-      # - name: Code Signing Setup - Setup SSM KSP on windows latest
-      #   shell: cmd
-      #   run: |
-      #     curl -X GET https://one.digicert.com/signingmanager/api-ui/v1/releases/smtools-windows-x64.msi/download -H "x-api-key:%SM_API_KEY%" -o smtools-windows-x64.msi
-      #     msiexec /i smtools-windows-x64.msi /quiet /qn
-      #     smksp_registrar.exe list
-      #     smctl.exe keypair ls
-      #     C:\Windows\System32\certutil.exe -csp "DigiCert Signing Manager KSP" -key -user
-      #     smksp_cert_sync.exe
-      #
-      # - name: Code Signing Setup - Sign using Signtool
-      #   run: |
-      #     signtool.exe sign /sha1 ${{ secrets.SM_CODE_SIGNING_CERT_SHA1_HASH }} /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 "./build/LPM-Setup.exe"
-      #     signtool.exe verify /v /pa "./build/LPM-Setup.exe"
-      #
-      # - name: Configure AWS Credentials
-      #   uses: aws-actions/configure-aws-credentials@v4.0.2
-      #   with:
-      #     aws-region: us-west-2
-      #     aws-access-key-id: ${{ secrets.LPM_S3_ACCESS_KEY_ID }}
-      #     aws-secret-access-key: ${{ secrets.LPM_S3_SECRET_ACCESS_KEY }}
-      #
-      # - name: Upload Installer to S3
-      #   run: |
-      #     aws s3 cp ./build/LPM-Setup.exe s3://loupe-lpm-assets/releases/latest/LPM-Setup.exe
-      #     aws s3 cp ./build/LPM-Setup.exe s3://loupe-lpm-assets/releases/${{ github.ref_name }}/LPM-Setup.exe
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
@@ -90,13 +36,94 @@ jobs:
           registry-url: 'https://npm.pkg.github.com'
           scope: '@loupeteam'
 
-      - name: Sync package.json version with tag
-        shell: pwsh
+      - name: Sync version from tag
+        shell: bash
         run: |
-          $version = "${{ github.ref_name }}" -replace '^v',''
-          npm version $version --no-git-tag-version --allow-same-version
+          version="${{ github.ref_name }}"
+          version="${version#v}"
+          npm version "$version" --no-git-tag-version --allow-same-version
+          python3 -c "
+          import json
+          with open('src/version.json', 'r') as f:
+              data = json.load(f)
+          data['version'] = '$version'
+          with open('src/version.json', 'w') as f:
+              json.dump(data, f, indent=4)
+          "
 
       - name: Publish to GitHub Packages
         run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # TEMPORARILY DISABLED: Code signing certificate is not currently working.
+  # Re-enable this job (windows-2022 runner required) once resolved.
+  # release-installer:
+  #   runs-on: windows-2022
+  #   timeout-minutes: 10
+  #   env:
+  #     SM_API_KEY: ${{ secrets.SM_API_KEY }}
+  #     SM_CLIENT_CERT_FILE: "D:\\Certificate_pkcs12.p12"
+  #     SM_CLIENT_CERT_PASSWORD: ${{ secrets.SM_CLIENT_CERT_PASSWORD }}
+  #     SM_HOST: ${{ secrets.SM_HOST }}
+  #   steps:
+  #     - name: Check out repository code
+  #       uses: actions/checkout@v4
+  #       with:
+  #         submodules: true
+  #
+  #     - name: Download Inno Setup installer
+  #       run: Invoke-WebRequest -Uri "https://jrsoftware.org/download.php/is.exe" -OutFile "is.exe"
+  #     - name: Install Inno Setup silently
+  #       run: .\is.exe /verysilent /dir="C:\Program Files\InnoSetup"
+  #
+  #     - name: Create the EXE Installer
+  #       working-directory: ./utils
+  #       run: ./BuildInstaller.bat
+  #
+  #     - name: Code Signing Setup - Setup Certificate
+  #       shell: bash
+  #       run: echo "${{secrets.SM_CLIENT_CERT_FILE_B64 }}" | base64 --decode > /d/Certificate_pkcs12.p12
+  #
+  #     - name: Code Signing Setup - add to path
+  #       shell: bash
+  #       run: |
+  #         echo "C:\Program Files (x86)\Windows Kits\10\App Certification Kit" >> $GITHUB_PATH
+  #         echo "C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools" >> $GITHUB_PATH
+  #         echo "C:\Program Files\DigiCert\DigiCert One Signing Manager Tools" >> $GITHUB_PATH
+  #
+  #     - name: Code Signing Setup - Setup SSM KSP on windows latest
+  #       shell: cmd
+  #       run: |
+  #         curl -X GET https://one.digicert.com/signingmanager/api-ui/v1/releases/smtools-windows-x64.msi/download -H "x-api-key:%SM_API_KEY%" -o smtools-windows-x64.msi
+  #         msiexec /i smtools-windows-x64.msi /quiet /qn
+  #         smksp_registrar.exe list
+  #         smctl.exe keypair ls
+  #         C:\Windows\System32\certutil.exe -csp "DigiCert Signing Manager KSP" -key -user
+  #         smksp_cert_sync.exe
+  #
+  #     - name: Code Signing Setup - Sign using Signtool
+  #       run: |
+  #         signtool.exe sign /sha1 ${{ secrets.SM_CODE_SIGNING_CERT_SHA1_HASH }} /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 "./build/LPM-Setup.exe"
+  #         signtool.exe verify /v /pa "./build/LPM-Setup.exe"
+  #
+  #     - name: Configure AWS Credentials
+  #       uses: aws-actions/configure-aws-credentials@v4.0.2
+  #       with:
+  #         aws-region: us-west-2
+  #         aws-access-key-id: ${{ secrets.LPM_S3_ACCESS_KEY_ID }}
+  #         aws-secret-access-key: ${{ secrets.LPM_S3_SECRET_ACCESS_KEY }}
+  #
+  #     - name: Upload Installer to S3
+  #       run: |
+  #         aws s3 cp ./build/LPM-Setup.exe s3://loupe-lpm-assets/releases/latest/LPM-Setup.exe
+  #         aws s3 cp ./build/LPM-Setup.exe s3://loupe-lpm-assets/releases/${{ github.ref_name }}/LPM-Setup.exe
+  #
+  #     - name: Attach EXE to GitHub Release
+  #       uses: softprops/action-gh-release@v2
+  #       with:
+  #         tag_name: ${{ github.ref_name }}
+  #         files: ./build/LPM-Setup.exe
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/bin/lpm.js
+++ b/bin/lpm.js
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+'use strict';
+
+const { spawnSync } = require('child_process');
+const path = require('path');
+
+const lpmScript = path.join(__dirname, '..', 'src', 'LPM.py');
+const python = process.platform === 'win32' ? 'python' : 'python3';
+
+const result = spawnSync(python, [lpmScript, ...process.argv.slice(2)], {
+  stdio: 'inherit',
+  shell: false,
+});
+
+process.exit(result.status ?? 1);

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "author": "Loupe",
   "license": "MIT",
   "scripts": {
-    "postinstall": "python -m pip install -r requirements.txt || python3 -m pip install -r requirements.txt"
+    "postinstall": "python -m pip install --user -r requirements.txt || python3 -m pip install --user -r requirements.txt"
   },
   "files": [
     "bin/",

--- a/package.json
+++ b/package.json
@@ -7,9 +7,16 @@
     "type": "git",
     "url": "git+https://github.com/loupeteam/LPM.git"
   },
+  "bin": {
+    "lpm": "bin/lpm.js"
+  },
   "author": "Loupe",
   "license": "MIT",
+  "scripts": {
+    "postinstall": "python -m pip install -r requirements.txt || python3 -m pip install -r requirements.txt"
+  },
   "files": [
+    "bin/",
     "src/",
     "requirements.txt",
     "docs/",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@loupeteam/lpm",
+  "version": "1.0.6",
+  "description": "LPM - Loupe Package Manager. A lightweight wrapper around NPM that processes Loupe packages.",
+  "homepage": "https://loupeteam.github.io/LoupeDocs/tools/lpm.html",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/loupeteam/LPM.git"
+  },
+  "author": "Loupe",
+  "license": "MIT",
+  "files": [
+    "src/",
+    "requirements.txt",
+    "docs/",
+    "files/",
+    "LICENSE",
+    "README.md"
+  ],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -13,10 +13,11 @@
   "author": "Loupe",
   "license": "MIT",
   "scripts": {
-    "postinstall": "python -m pip install --user -r requirements.txt || python3 -m pip install --user -r requirements.txt"
+    "postinstall": "node scripts/postinstall.js"
   },
   "files": [
     "bin/",
+    "scripts/",
     "src/",
     "requirements.txt",
     "docs/",

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const { spawnSync } = require('child_process');
+
+const candidates = ['python', 'python3'];
+let py = null;
+
+for (const cmd of candidates) {
+  const check = spawnSync(cmd, ['-m', 'pip', '--version'], { stdio: 'ignore' });
+  if (check.status === 0) {
+    py = cmd;
+    break;
+  }
+}
+
+if (!py) {
+  console.error(
+    '\nLPM postinstall error: Python 3 and pip are required but were not found on PATH.\n' +
+    'Please install Python 3 with pip (https://www.python.org/downloads/) and re-run npm install.\n'
+  );
+  process.exit(1);
+}
+
+const result = spawnSync(
+  py,
+  ['-m', 'pip', 'install', '--user', '-r', 'requirements.txt'],
+  { stdio: 'inherit' }
+);
+
+process.exit(result.status || 0);


### PR DESCRIPTION
## What:

Update release to publish to loupeteam github packages allowing install via `npm install @loupeteam/lpm`. 

## Why:

Currently our EXE certificate is not working. Regardless I think a simple npm install is a nice interface to use this package. 