### PR TITLE
feat: add --no-check flag to lpm login for CI machine tokens

### DIFF
--- a/src/LPM.py
+++ b/src/LPM.py
@@ -97,7 +97,9 @@ def cmd_login(args):
         cprint('Please follow the prompts below to log in using valid GitHub credentials.', 'yellow')
         token = input(colored('? ', 'green') + 'Enter your personal access token: ')
         login(token)
-    if isAuthenticated():
+    if getattr(args, 'no_check', False):
+        print('Credentials stored (authentication check skipped).')
+    elif isAuthenticated():
         print(colored(f'New credentials for {getAuthenticatedUser()} successfully stored.', 'green'))
     else:
         print(colored('Error: invalid credentials. Please try again.', 'red'))
@@ -412,6 +414,8 @@ def _build_parser(prog_name):
     # login
     p = sub.add_parser('login', help='Authenticate with the GitHub package registry')
     p.add_argument('-t', '--token', type=str, help='Personal Access Token required for silent login')
+    p.add_argument('--no-check', action='store_true', dest='no_check',
+                   help='Skip the post-login authentication check (useful for CI machine tokens)')
     p.set_defaults(func=cmd_login)
 
     # logout


### PR DESCRIPTION
## Summary

Adds a `--no-check` flag to the `lpm login` subcommand. When set, the token is written to `.npmrc` but the `npm whoami` verification step is skipped.

## Motivation

CI environments using short-lived machine tokens (e.g. GitHub Actions `GITHUB_TOKEN`) have no npm user identity, so `npm whoami` always fails and causes `lpm login` to report invalid credentials even though the token is valid for package registry access.

## Usage

```sh
lpm login --silent --token ${{ secrets.GITHUB_TOKEN }} --no-check
```

## Changes

- Added `--no-check` argument to the `login` subparser in `_build_parser()`
- Guarded the `isAuthenticated()` / `getAuthenticatedUser()` call in `cmd_login()` — when `--no-check` is set, prints `"Credentials stored (authentication check skipped)."` instead