### PR TITLE
feat: add --no-auth-check global flag to skip auth check on any command

### DIFF
--- a/src/LPM.py
+++ b/src/LPM.py
@@ -37,7 +37,7 @@ from lpm_core import *
 # subcommand for argparse to recognise them.  Centralised here so that
 # _hoist_global_flags(), the fallback parser, and any future code all stay
 # in sync automatically.
-_GLOBAL_FLAG_SPELLINGS = {'-s', '--silent', '-nc', '--nocolor'}
+_GLOBAL_FLAG_SPELLINGS = {'-s', '--silent', '-nc', '--nocolor', '--no-auth-check'}
 
 
 # ---------------------------------------------------------------------------
@@ -104,6 +104,8 @@ def cmd_login(args):
         token = input(colored('? ', 'green') + 'Enter your personal access token: ')
         login(token)
     if getattr(args, 'no_check', False):
+        cprint('Warning: --no-check is deprecated; use --no-auth-check instead.', 'yellow')
+    if getattr(args, 'no_auth_check', False) or getattr(args, 'no_check', False):
         print('Credentials stored (authentication check skipped).')
     elif isAuthenticated():
         print(colored(f'New credentials for {getAuthenticatedUser()} successfully stored.', 'green'))
@@ -413,6 +415,8 @@ def _build_parser(prog_name):
                         help='Execute commands silently with default values and no operator prompts')
     parser.add_argument('-nc', '--nocolor', action='store_true',
                         help="Don't color the output - to avoid dependency on termcolor")
+    parser.add_argument('--no-auth-check', action='store_true', dest='no_auth_check',
+                        help='Skip the authentication check before running the command (useful for CI machine tokens)')
     parser.add_argument('-v', '--version', action='version', version='%(prog)s: ' + __version__)
 
     sub = parser.add_subparsers(dest='cmd', metavar='command')
@@ -421,7 +425,7 @@ def _build_parser(prog_name):
     p = sub.add_parser('login', help='Authenticate with the GitHub package registry')
     p.add_argument('-t', '--token', type=str, help='Personal Access Token required for silent login')
     p.add_argument('--no-check', action='store_true', dest='no_check',
-                   help='Skip the post-login authentication check (useful for CI machine tokens)')
+                   help='(Deprecated, use --no-auth-check) Skip the post-login authentication check')
     p.set_defaults(func=cmd_login)
 
     # logout
@@ -575,6 +579,7 @@ def main():
         # Keep these in sync with _GLOBAL_FLAG_SPELLINGS.
         fallback.add_argument('-s', '--silent', action='store_true')
         fallback.add_argument('-nc', '--nocolor', action='store_true')
+        fallback.add_argument('--no-auth-check', action='store_true', dest='no_auth_check')
         ns, leftover = fallback.parse_known_args(raw_args)
         ns.cmd = leftover[0] if leftover else ''
         ns.packages = leftover[1:]
@@ -597,7 +602,7 @@ def main():
         return
 
     # Auth gate.
-    if ns.cmd not in _NO_AUTH and not isAuthenticated():
+    if ns.cmd not in _NO_AUTH and not getattr(ns, 'no_auth_check', False) and not isAuthenticated():
         cprint('No credentials found. Please call lpm login before attempting other operations.', 'yellow')
         return
 

--- a/test/test_lpm.py
+++ b/test/test_lpm.py
@@ -148,6 +148,35 @@ class TestLpm:
         finally:
             monkeypatch.undo()
 
+    def test_hoist_no_auth_check_after_subcommand(self):
+        """--no-auth-check placed after the subcommand should be hoisted."""
+        hoisted = LPM._hoist_global_flags(["install", "somepkg", "--no-auth-check"])
+        assert hoisted == ["--no-auth-check", "install", "somepkg"]
+
+    def test_hoist_parse_no_auth_check_after_subcommand(self, monkeypatch):
+        """lpm install --no-auth-check should parse without error and set no_auth_check=True."""
+        monkeypatch.chdir(self.test_dir)
+        try:
+            parser, sub = LPM._build_parser("LPM")
+            raw_args = LPM._hoist_global_flags(["install", "--no-auth-check"])
+            ns = parser.parse_args(raw_args)
+            assert ns.no_auth_check is True
+            assert ns.cmd == "install"
+        finally:
+            monkeypatch.undo()
+
+    def test_login_no_check_deprecated_alias(self, monkeypatch):
+        """lpm login --no-check should still parse (backwards compat); no_auth_check unset."""
+        monkeypatch.chdir(self.test_dir)
+        try:
+            parser, sub = LPM._build_parser("LPM")
+            ns = parser.parse_args(["login", "--no-check"])
+            assert ns.no_check is True
+            # no_auth_check is the new global flag; --no-check does not set it
+            assert ns.no_auth_check is False
+        finally:
+            monkeypatch.undo()
+
     # Prior to installing atn, install 1 of 3 dependencies
     def test_stringext_install(self, monkeypatch):
         monkeypatch.setattr(sys, "argv", ["lpm.py", "install", "stringext"])


### PR DESCRIPTION
--no-auth-check is a global flag (like --silent) that can appear before or after the subcommand. It bypasses the pre-command isAuthenticated() gate, making it useful for CI environments with machine tokens.

The existing --no-check on lpm login is preserved for backwards compatibility but is now deprecated; a warning is printed when it is used. The post-login verification in cmd_login also respects the new global flag.

Tests added for:
- --no-auth-check hoisting
- --no-auth-check end-to-end parsing
- --no-check backward-compat alias parsing

## What:
Describe what the changes are.

## Why:
Describe the improvement(s) that these changes bring. If applicable, describe the reasoning behind key implementation details.