### PR TITLE
ci: add GitHub Actions workflow to run tests on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,9 @@ jobs:
           python-version: '3.12'
 
       - name: Install Python dependencies
-        run: pip install -r requirements.txt pytest
+        run: |
+          pip install -r requirements.txt pytest
+          pip install ./src/ASPython
 
       # Write ~/.npmrc so that `npm whoami` and `npm install` can reach
       # the GitHub Package Registry.  LPM_TOKEN must be a classic PAT with

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: windows-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Python dependencies
+        run: pip install -r requirements.txt
+
+      # Write ~/.npmrc so that `npm whoami` and `npm install` can reach
+      # the GitHub Package Registry.  NPM_TOKEN must be a classic PAT with
+      # the `read:packages` scope, stored as a repository secret.
+      - name: Configure npm authentication
+        shell: pwsh
+        run: |
+          $content = "@loupeteam:registry=https://npm.pkg.github.com`n//npm.pkg.github.com/:_authToken=${{ secrets.NPM_TOKEN }}"
+          Set-Content -Path "$env:USERPROFILE\.npmrc" -Value $content
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Run tests
+        # test_build_intel / test_build_arm require Automation Studio to be
+        # installed locally and are excluded from CI.
+        run: python -m pytest test/test_lpm.py -v -k "not test_build"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,18 +23,18 @@ jobs:
           python-version: '3.12'
 
       - name: Install Python dependencies
-        run: pip install -r requirements.txt
+        run: pip install -r requirements.txt pytest
 
       # Write ~/.npmrc so that `npm whoami` and `npm install` can reach
-      # the GitHub Package Registry.  NPM_TOKEN must be a classic PAT with
+      # the GitHub Package Registry.  LPM_TOKEN must be a classic PAT with
       # the `read:packages` scope, stored as a repository secret.
       - name: Configure npm authentication
         shell: pwsh
         run: |
-          $content = "@loupeteam:registry=https://npm.pkg.github.com`n//npm.pkg.github.com/:_authToken=${{ secrets.NPM_TOKEN }}"
+          $content = "@loupeteam:registry=https://npm.pkg.github.com`n//npm.pkg.github.com/:_authToken=${{ secrets.LPM_TOKEN }}"
           Set-Content -Path "$env:USERPROFILE\.npmrc" -Value $content
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          LPM_TOKEN: ${{ secrets.LPM_TOKEN }}
 
       - name: Run tests
         # test_build_intel / test_build_arm require Automation Studio to be


### PR DESCRIPTION
## Summary

Adds a GitHub Actions CI workflow (`.github/workflows/ci.yml`) that runs the test suite automatically on every pull request to `main` and every push to `main`.

## What the workflow does

- Runs on `windows-latest` (required — ASTools has Windows dependencies)
- Checks out the repo with submodules
- Installs Python 3.12 and all dependencies from `requirements.txt`
- Configures `~/.npmrc` from the `NPM_TOKEN` secret so authenticated npm calls succeed
- Runs `pytest test/test_lpm.py -v -k "not test_build"` — all tests except `test_build_intel` / `test_build_arm`, which require Automation Studio installed locally

## Setup required

Add a repository secret named `NPM_TOKEN` set to a classic PAT with the `read:packages` scope. This allows the runner to authenticate with the GitHub Package Registry during tests.