### PR TITLE
fix: update test_version regex to support pre-release version suffixes

### DIFF
--- a/test/test_lpm.py
+++ b/test/test_lpm.py
@@ -112,7 +112,7 @@ class TestLpm:
         
         # Verify output
         captured = capsys.readouterr()
-        version_output = re.fullmatch(r"LPM: \d+\.\d+\.\d+\n", captured.out)
+        version_output = re.fullmatch(r"LPM: \d+\.\d+\.\d+[^\n]*\n", captured.out)
         assert version_output is not None
 
     def test_hoist_silent_after_subcommand(self):


### PR DESCRIPTION
## Summary

- `TestLpm.test_version` was failing because the regex `r"LPM: \d+\.\d+\.\d+\n"` only matched plain `X.Y.Z` version strings
- Version was bumped to `1.2.0-beta.1` in the recent beta release, which includes a pre-release suffix that the old pattern rejected
- Updated the regex to `r"LPM: \d+\.\d+\.\d+[^\n]*\n"` to allow any optional suffix after the patch number

## Test plan

- [x] Run `pytest test/test_lpm.py::TestLpm::test_version` — should pass with `1.2.0-beta.1` and any future pre-release versions
- [x] Verify plain `X.Y.Z` releases still match (the `[^\n]*` allows zero characters, so it's backwards compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)