### PR TITLE
ci: add Ruff lint and format to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,29 @@ on:
     branches: [main]
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        # No submodules: ASPython is excluded from Ruff via pyproject.toml.
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Ruff
+        run: pip install ruff==0.15.12
+
+      - name: Ruff lint
+        run: ruff check .
+
+      - name: Ruff format check
+        run: ruff format --check .
+
   test:
     runs-on: windows-latest
     timeout-minutes: 20

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install Ruff
-        run: pip install ruff==0.15.12
+        run: python -m pip install ruff==0.15.12
 
       - name: Ruff lint
         run: ruff check .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,24 @@
+[tool.ruff]
+target-version = "py312"
+# TODO: tighten line-length back toward 88/100 once existing long lines are wrapped.
+line-length = 120
+extend-exclude = ["src/ASPython"]
+
+[tool.ruff.lint]
+select = [
+    "E",   # pycodestyle errors (PEP 8)
+    "W",   # pycodestyle warnings (PEP 8)
+    "F",   # pyflakes (unused imports, undefined names)
+    "I",   # isort (import sorting)
+]
+# TODO: replace bare `except:` with explicit exception types and remove E722 ignore.
+# TODO: wrap or shorten the long lines (mostly user-facing prompts) and remove E501 ignore.
+ignore = ["E722", "E501"]
+
+# TODO: replace `from lpm_core import *` in src/LPM.py with explicit imports
+# (or `import lpm_core` + qualified calls) and drop the F403/F405 ignores.
+[tool.ruff.lint.per-file-ignores]
+"src/LPM.py" = ["F403", "F405"]
+
+[tool.ruff.format]
+quote-style = "single"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,3 +22,9 @@ ignore = ["E722", "E501"]
 
 [tool.ruff.format]
 quote-style = "single"
+
+[tool.ruff.lint.isort]
+# `aspython` is a third-party package installed from src/ASPython. Declare it
+# explicitly so isort classifies it the same way regardless of whether the
+# submodule directory is present in the working tree.
+known-third-party = ["aspython"]

--- a/src/LPM.py
+++ b/src/LPM.py
@@ -1,4 +1,4 @@
-'''
+"""
  * File: LPM.py
  * Copyright (c) 2023 Loupe
  * https://loupe.team
@@ -10,7 +10,7 @@ This is a lightweight wrapper around NPM that processes Loupe packages.
 
 This file contains the command-line interface only. The underlying
 functionality lives in lpm_core.py.
-'''
+"""
 
 import argparse
 import ctypes
@@ -26,9 +26,9 @@ import aspython as ASTools
 from lpm_core import *
 
 version_file = os.path.normpath(os.path.join(os.path.dirname(__file__), 'version.json'))
-with open(version_file, "r") as f:
+with open(version_file, 'r') as f:
     data = json.load(f)
-    __version__ = data["version"]
+    __version__ = data['version']
 
 __author__ = 'Andrew Musser'
 
@@ -45,11 +45,14 @@ _GLOBAL_FLAG_SPELLINGS = {'-s', '--silent', '-nc', '--nocolor'}
 # by all the cmd_* handlers below.
 # ---------------------------------------------------------------------------
 
+
 def _identity(text, color):
     return text
 
+
 def _plain_print(text, color):
     print(text)
+
 
 colored = _identity
 cprint = _plain_print
@@ -65,8 +68,17 @@ _NO_AUTH = {'login', 'logout', 'delete', 'status'}
 # Commands that may run before `lpm init` has been invoked (i.e. don't require
 # a package.json in the current directory).
 _NO_INIT_REQUIRED = {
-    'login', 'logout', 'delete', 'status',
-    'view', 'info', 'viewall', 'type', 'docs', 'as', 'init',
+    'login',
+    'logout',
+    'delete',
+    'status',
+    'view',
+    'info',
+    'viewall',
+    'type',
+    'docs',
+    'as',
+    'init',
 }
 
 
@@ -89,6 +101,7 @@ def _normalize_packages(raw_packages):
 # ---------------------------------------------------------------------------
 # Subcommand handlers. Each takes the parsed args namespace.
 # ---------------------------------------------------------------------------
+
 
 def cmd_login(args):
     if args.silent:
@@ -180,10 +193,13 @@ def cmd_as(args):
     print('Opening Automation Studio...')
     asBin = os.path.join(ASTools.getASPath(project.ASVersion), 'pg.exe')
     if not os.path.isfile(asBin):
-        cprint(f'Project was last opened with {project.ASVersion}, but that version is not installed. Trying to open with AS410 instead...', 'yellow')
+        cprint(
+            f'Project was last opened with {project.ASVersion}, but that version is not installed. Trying to open with AS410 instead...',
+            'yellow',
+        )
         # If that version isn't installed, try something else. Just hard-coding 410 for now because it's what I have installed!
         asBin = os.path.join(ASTools.getASPath('AS410'), 'pg.exe')
-    cmd = [asBin, '\"' + os.path.join(os.getcwd(), f'{project.name}.apj') + '\"']
+    cmd = [asBin, '"' + os.path.join(os.getcwd(), f'{project.name}.apj') + '"']
     executeAndContinue(cmd)
     time.sleep(3)
     cprint('Wait for it...', 'yellow')
@@ -214,7 +230,14 @@ def cmd_init(args):
         initializeProject()
         arg_folder = False
         if not args.silent:
-            text = input(colored('? ', 'green') + colored('Would you like to initialize LPM with the existing Loupe libraries in your Automation Studio project?', 'yellow') + ' (y/N) ')
+            text = input(
+                colored('? ', 'green')
+                + colored(
+                    'Would you like to initialize LPM with the existing Loupe libraries in your Automation Studio project?',
+                    'yellow',
+                )
+                + ' (y/N) '
+            )
             if text.lower() in ('y', 'yes'):
                 arg_folder = importLibraries()
         configureProject(args)
@@ -234,7 +257,14 @@ def cmd_init(args):
 
     else:
         if not args.silent:
-            text = input(colored('? ', 'green') + colored('No Automation Studio project found. Would you like to initialize this directory with a starter AS project?', 'yellow') + ' (Y/n) ')
+            text = input(
+                colored('? ', 'green')
+                + colored(
+                    'No Automation Studio project found. Would you like to initialize this directory with a starter AS project?',
+                    'yellow',
+                )
+                + ' (Y/n) '
+            )
         else:
             text = 'n'
         if text.lower() in ('n', 'no'):
@@ -283,7 +313,7 @@ def cmd_install(args):
         if packages:
             print('Attempting to install source for ' + ', '.join(args.packages) + '...')
         sourceDependencies = []
-        for (package, packageVersion) in zip(packages, packageVersions):
+        for package, packageVersion in zip(packages, packageVersions):
             installSource(package, packageVersion, sourceDependencies)
 
     # Deploy relevant objects to cpu.sw.
@@ -307,8 +337,11 @@ def cmd_install(args):
             if packageType == 'project':
                 return
     if deploymentConfigs is None:
-        cprint("Note that the installed packages have not been deployed.", "yellow")
-        cprint("You will need to do this manually, or you can configure deployment targets with the 'lpm configure' command.", 'yellow')
+        cprint('Note that the installed packages have not been deployed.', 'yellow')
+        cprint(
+            "You will need to do this manually, or you can configure deployment targets with the 'lpm configure' command.",
+            'yellow',
+        )
 
 
 def cmd_uninstall(args):
@@ -330,21 +363,21 @@ def cmd_git(args):
     packages, _ = _normalize_packages(args.packages)
     gitClient = getPackageManifestField('package.json', ['lpmConfig', 'gitClient'])
     if gitClient == '':
-        cprint("No Git client configured (please run lpm configure)", "yellow")
+        cprint('No Git client configured (please run lpm configure)', 'yellow')
         return
     if gitClient != 'GitExtensions':
-        cprint(f"We don't support {gitClient}, are you kidding?", "yellow")
+        cprint(f"We don't support {gitClient}, are you kidding?", 'yellow')
         return
-    sourceInfoFilePath = os.path.join(".", "TempObjects", "sourceInfo.json")
+    sourceInfoFilePath = os.path.join('.', 'TempObjects', 'sourceInfo.json')
     sourceInfo = getJsonData(sourceInfoFilePath)
     print(f'Opening {gitClient} for these packages: ' + ', '.join(args.packages))
     for package in packages:
-        repoPath = sourceInfo.get(package, {}).get("repoPath", None)
+        repoPath = sourceInfo.get(package, {}).get('repoPath', None)
         if repoPath is not None:
-            cmd = ['gitex.cmd', 'openrepo', '\"' + os.path.join(os.getcwd(), repoPath) + '\"']
+            cmd = ['gitex.cmd', 'openrepo', '"' + os.path.join(os.getcwd(), repoPath) + '"']
             executeAndContinue(cmd)
         else:
-            cprint(f"Could not find repo location for {package}. Verify that it is installed as source.", "yellow")
+            cprint(f'Could not find repo location for {package}. Verify that it is installed as source.', 'yellow')
 
 
 def cmd_publish(args):
@@ -365,7 +398,14 @@ def cmd_publish(args):
     if args.silent:
         text = 'y'
     else:
-        text = input(colored('? ', 'green') + 'Are you sure you want to publish ' + colored(data['name'], 'yellow') + ' version ' + colored(data['version'], 'yellow') + '? (y/N) ')
+        text = input(
+            colored('? ', 'green')
+            + 'Are you sure you want to publish '
+            + colored(data['name'], 'yellow')
+            + ' version '
+            + colored(data['version'], 'yellow')
+            + '? (y/N) '
+        )
     if text.lower() not in ('y', 'yes'):
         return
     try:
@@ -375,7 +415,7 @@ def cmd_publish(args):
         execute(['npm', 'publish'], True)
         cprint('Successfully published ' + data['name'] + ' version ' + data['version'] + '.', 'green')
     except:
-        cprint("Error while publishing. Please check the detailed error message above.", 'yellow')
+        cprint('Error while publishing. Please check the detailed error message above.', 'yellow')
 
 
 def cmd_list(args):
@@ -400,16 +440,22 @@ def cmd_npm_passthrough(args):
 # Argument parser construction.
 # ---------------------------------------------------------------------------
 
+
 def _build_parser(prog_name):
     parser = argparse.ArgumentParser(
         description='A lightweight wrapper around NPM for Automation Studio dependency management',
         prog=prog_name,
     )
     # Global flags (apply to all subcommands).
-    parser.add_argument('-s', '--silent', action='store_true',
-                        help='Execute commands silently with default values and no operator prompts')
-    parser.add_argument('-nc', '--nocolor', action='store_true',
-                        help="Don't color the output - to avoid dependency on termcolor")
+    parser.add_argument(
+        '-s',
+        '--silent',
+        action='store_true',
+        help='Execute commands silently with default values and no operator prompts',
+    )
+    parser.add_argument(
+        '-nc', '--nocolor', action='store_true', help="Don't color the output - to avoid dependency on termcolor"
+    )
     parser.add_argument('-v', '--version', action='version', version='%(prog)s: ' + __version__)
 
     sub = parser.add_subparsers(dest='cmd', metavar='command')
@@ -457,10 +503,12 @@ def _build_parser(prog_name):
 
     # init
     p = sub.add_parser('init', help='Initialize the current directory for use with LPM')
-    p.add_argument('-prj', '--asproject', action='store_true',
-                   help='Force LPM to treat current directory as AS project')
-    p.add_argument('-lib', '--aslibrary', action='store_true',
-                   help='Force LPM to treat current directory as AS library')
+    p.add_argument(
+        '-prj', '--asproject', action='store_true', help='Force LPM to treat current directory as AS project'
+    )
+    p.add_argument(
+        '-lib', '--aslibrary', action='store_true', help='Force LPM to treat current directory as AS library'
+    )
     p.set_defaults(func=cmd_init)
 
     # configure
@@ -474,8 +522,7 @@ def _build_parser(prog_name):
     # install
     p = sub.add_parser('install', help='Install one or more packages')
     p.add_argument('packages', nargs='*')
-    p.add_argument('-src', '--source', action='store_true',
-                   help='Use source code for libraries instead of binaries')
+    p.add_argument('-src', '--source', action='store_true', help='Use source code for libraries instead of binaries')
     p.set_defaults(func=cmd_install)
 
     # uninstall
@@ -506,8 +553,8 @@ def _hoist_global_flags(argv):
     This allows both ``lpm --silent install`` and ``lpm install --silent``.
     """
     global_flags = _GLOBAL_FLAG_SPELLINGS
-    prefix = []   # tokens up to and including the subcommand
-    suffix = []   # tokens after the subcommand
+    prefix = []  # tokens up to and including the subcommand
+    suffix = []  # tokens after the subcommand
     cmd_found = False
     for token in argv:
         if not cmd_found:
@@ -554,6 +601,7 @@ def _is_known_command(parser, sub, argv):
 # Entry point.
 # ---------------------------------------------------------------------------
 
+
 def main():
     global colored, cprint
 
@@ -581,6 +629,7 @@ def main():
     if not ns.nocolor:
         from termcolor import colored as _colored
         from termcolor import cprint as _cprint
+
         colored = _colored
         cprint = _cprint
     else:
@@ -605,7 +654,7 @@ def main():
     ns.func(ns)
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     # Configure colored logger
     logging.basicConfig(stream=sys.stderr, level=logging.INFO)
     kernel32 = ctypes.windll.kernel32

--- a/src/LPM.py
+++ b/src/LPM.py
@@ -4,8 +4,7 @@
  * https://loupe.team
  *
  * This file is part of LPM, licensed under the MIT License.
-'''
-'''
+
 LPM
 This is a lightweight wrapper around NPM that processes Loupe packages.
 
@@ -13,13 +12,18 @@ This file contains the command-line interface only. The underlying
 functionality lives in lpm_core.py.
 '''
 
-import os.path
-import json
-import sys
 import argparse
-import logging
 import ctypes
+import json
+import logging
+import os.path
+import sys
 import time
+
+import aspython as ASTools
+
+# Core LPM functionality. The CLI delegates to functions defined in lpm_core.
+from lpm_core import *
 
 version_file = os.path.normpath(os.path.join(os.path.dirname(__file__), 'version.json'))
 with open(version_file, "r") as f:
@@ -27,11 +31,6 @@ with open(version_file, "r") as f:
     __version__ = data["version"]
 
 __author__ = 'Andrew Musser'
-
-import aspython as ASTools
-
-# Core LPM functionality. The CLI delegates to functions defined in lpm_core.
-from lpm_core import *
 
 # Spellings of flags that are global (top-level) and must appear before the
 # subcommand for argparse to recognise them.  Centralised here so that
@@ -354,7 +353,7 @@ def cmd_publish(args):
         cprint('Error: the package name must include the @loupeteam scope prefix.', 'yellow')
         return
     try:
-        repoUrl = data['repository']['url']  # triggers an exception if missing
+        data['repository']['url']  # triggers an exception if missing
     except:
         cprint('Error: the package.json file must include a repository parameter', 'yellow')
         cprint('For example:', 'yellow')
@@ -580,7 +579,8 @@ def main():
 
     # Configure output coloring now that --nocolor is known.
     if not ns.nocolor:
-        from termcolor import colored as _colored, cprint as _cprint
+        from termcolor import colored as _colored
+        from termcolor import cprint as _cprint
         colored = _colored
         cprint = _cprint
     else:

--- a/src/lpm_core.py
+++ b/src/lpm_core.py
@@ -1,4 +1,4 @@
-'''
+"""
  * File: lpm_core.py
  * Copyright (c) 2023 Loupe
  * https://loupe.team
@@ -11,7 +11,7 @@ This module contains the underlying package-management, authentication, manifest
 manipulation, and subprocess helpers used by the LPM CLI. The CLI lives in
 LPM.py and is responsible for argument parsing and user-facing output;
 everything else lives here so it can be reused and tested in isolation.
-'''
+"""
 
 import json
 import os
@@ -36,22 +36,25 @@ def isAuthenticated():
     else:
         return True
 
+
 def getAuthenticatedUser():
     command = []
     command.append('npm whoami')
     command.append('--registry=https://npm.pkg.github.com')
     # Catch the special case where it's the loupe-devops-admin, as this should be converted to a different user name.
     user = executeAndReturnStdOut(command)
-    if (user == 'loupe-devops-admin'):
+    if user == 'loupe-devops-admin':
         return 'default-user'
     else:
         return user
+
 
 def getLocalToken():
     # Search in the local .npmrc file for this token.
     f = open(os.path.join(os.path.expanduser('~'), '.npmrc'), 'r')
     text = f.readlines()
-    return re.search("_authToken=(.+)", "\n".join(text)).group(1)
+    return re.search('_authToken=(.+)', '\n'.join(text)).group(1)
+
 
 # Bootstrap the project with required files.
 def initializeProject():
@@ -60,8 +63,9 @@ def initializeProject():
         print('Package.json already exists, skipping creation')
     else:
         # Set up the package.json file.
-        execute(['npm' ,'init', '-y'], True)
+        execute(['npm', 'init', '-y'], True)
         print('Created package.json file')
+
 
 # Grab a list of existing libraries in the Loupe folder.
 def importLibraries():
@@ -95,6 +99,7 @@ def importLibraries():
     # librariesPkg = ASTools.Package('./Logical/Libraries')
     # librariesPkg.removeObject('_ARG')
 
+
 # Login silently by manually creating a the .npmrc file in the user directory.
 def login(token):
     f = open(os.path.join(os.path.expanduser('~'), '.npmrc'), 'w')
@@ -104,10 +109,11 @@ def login(token):
     f.write('\n'.join(text))
     f.close()
 
+
 # Logout of the Github registry.
 def logout():
     # If there's a local .npmrc file, remove it.
-    if(os.path.exists('./.npmrc')):
+    if os.path.exists('./.npmrc'):
         os.remove('./.npmrc')
     # And perform the npm logout to globally logout as well.
     command = []
@@ -116,16 +122,18 @@ def logout():
     command.append('--registry=https://npm.pkg.github.com')
     executeStandard(command)
 
+
 # Remove all LPM references from the project.
 def deleteProject():
-    if (os.path.isfile('./.npmrc')):
+    if os.path.isfile('./.npmrc'):
         os.remove('./.npmrc')
-    if (os.path.isfile('./package.json')):
+    if os.path.isfile('./package.json'):
         os.remove('./package.json')
-    if (os.path.isdir('./node_modules/')):
+    if os.path.isdir('./node_modules/'):
         shutil.rmtree('./node_modules/')
-    if (os.path.isfile('./package-lock.json')):
+    if os.path.isfile('./package-lock.json'):
         os.remove('./package-lock.json')
+
 
 def configureProject(args):
     try:
@@ -138,7 +146,10 @@ def configureProject(args):
         deploymentConfigs = []
     if (args.nocolor) or (args.silent):
         print('Support for interactive prompts is disabled. Default values will be assigned to the package.json file.')
-        print('All configurations in the project are being assigned as deployment targets: ' + ' '.join(project.buildConfigNames))
+        print(
+            'All configurations in the project are being assigned as deployment targets: '
+            + ' '.join(project.buildConfigNames)
+        )
         setPackageManifestField('package.json', 'deploymentConfigs', project.buildConfigNames)
     else:
         from InquirerPy import get_style, inquirer
@@ -148,47 +159,59 @@ def configureProject(args):
         configOptions = []
         for config in project.buildConfigNames:
             configOptions.append(Choice(config, enabled=(config in deploymentConfigs)))
-        print(colored("?", "green") + colored(" Which AS configuration(s) would you like future packages deployed to?", "yellow"))
+        print(
+            colored('?', 'green')
+            + colored(' Which AS configuration(s) would you like future packages deployed to?', 'yellow')
+        )
         configs = inquirer.checkbox(
             message="(press 'space' to toggle one, 'a' to select all, 't' to toggle all)",
-            style=get_style({"questionmark": "#00ff00", "pointer": "#ffff00"}),
+            style=get_style({'questionmark': '#00ff00', 'pointer': '#ffff00'}),
             choices=configOptions,
             cycle=False,
-            keybindings={
-                "toggle-all-true": [{ "key": "a"}],
-                "toggle-all-false": [{ "key": "t" }]
-            }
+            keybindings={'toggle-all-true': [{'key': 'a'}], 'toggle-all-false': [{'key': 't'}]},
         ).execute()
         setPackageManifestField('package.json', 'deploymentConfigs', configs)
-        if (len(configs) > 0):
-            cprint("The following configurations were successfully added to the deployment list: " + ", ".join(configs), "green")
+        if len(configs) > 0:
+            cprint(
+                'The following configurations were successfully added to the deployment list: ' + ', '.join(configs),
+                'green',
+            )
         else:
-            cprint("No configurations used for deployments", "green")
+            cprint('No configurations used for deployments', 'green')
 
         # Config question #2: Configure a Git client.
         # Check to see if there already is a configuration, and if so display that.
         gitClient = getPackageManifestField('package.json', ['lpmConfig', 'gitClient'])
         if gitClient is None:
             gitClient = ''
-        availableClients = ['GitExtensions', 'GitKraken', 'SourceTree', ''] # Note that these are available but not all supported (=
+        availableClients = [
+            'GitExtensions',
+            'GitKraken',
+            'SourceTree',
+            '',
+        ]  # Note that these are available but not all supported (=
         configOptions = []
         for client in availableClients:
-            if(client == ''):
+            if client == '':
                 configOptions.append(Choice(client, name='None', enabled=(client == gitClient)))
             else:
                 configOptions.append(Choice(client, enabled=(client == gitClient)))
-        print(colored("?", "green") + colored(" Which Git client would you like to use to introspect source libraries?", "yellow"))
+        print(
+            colored('?', 'green')
+            + colored(' Which Git client would you like to use to introspect source libraries?', 'yellow')
+        )
         selectedClient = inquirer.select(
             message="(press 'enter' to select)",
-            style=get_style({"questionmark": "#00ff00", "pointer": "#ffff00"}),
+            style=get_style({'questionmark': '#00ff00', 'pointer': '#ffff00'}),
             choices=configOptions,
-            cycle=False
+            cycle=False,
         ).execute()
         setPackageManifestField('package.json', 'gitClient', selectedClient)
-        if (selectedClient != ''):
-            cprint(f"{selectedClient} has been configured as the preferred Git client", "green")
+        if selectedClient != '':
+            cprint(f'{selectedClient} has been configured as the preferred Git client', 'green')
         else:
-            cprint("No Git client selected", "green")
+            cprint('No Git client selected', 'green')
+
 
 def getPackageType(path):
     packageType = None
@@ -198,7 +221,7 @@ def getPackageType(path):
         # First check for the lpm->type metadata.
         packageType = getPackageManifestField(manifestFilePath, ['lpm', 'type'])
     # If the field is not present, or the file is not present, then search manually for an indicative file extension.
-    if (packageType is None):
+    if packageType is None:
         try:
             ASTools.Project(path)
             packageType = 'project'
@@ -218,18 +241,20 @@ def getPackageType(path):
     else:
         return packageType
 
+
 # Perform the NPM install.
 def installPackages(packages, packageVersions):
     command = []
     command.append('npm install')
     # force packages names to lowercase
     packages = [package.lower() for package in packages]
-    for (item, version) in zip(packages, packageVersions):
-        if(version != ''):
+    for item, version in zip(packages, packageVersions):
+        if version != '':
             command.append(f'{item}@{version}')
         else:
             command.append(item)
     execute(command, False)
+
 
 # Perform the NPM uninstall.
 def uninstallPackages(packages):
@@ -238,6 +263,7 @@ def uninstallPackages(packages):
     for item in packages:
         command.append(item)
     execute(command, False)
+
 
 # Install lpm package source by cloning package's repo folder
 def installSource(package, version, sourceDependencies=None):
@@ -261,12 +287,14 @@ def installSource(package, version, sourceDependencies=None):
         else:
             # Folder exists already.
             if '.git' in os.listdir(repoPath):
-                print(f"Repository for package {package} already exists. Cloning skipped.")
+                print(f'Repository for package {package} already exists. Cloning skipped.')
             else:
-                raise Exception(f"{package} repository folder \"{repoName}\" exists, but does not contain expected structure.")
+                raise Exception(
+                    f'{package} repository folder "{repoName}" exists, but does not contain expected structure.'
+                )
 
         # And then checkout the correct commit if it's been specified.
-        if (version != ''):
+        if version != '':
             command1b = []
             command1b.append(f'git -C {repoPath} checkout')
             command1b.append(version)
@@ -287,7 +315,7 @@ def installSource(package, version, sourceDependencies=None):
             packageManifest = os.path.join(packageSourcePath, 'package.json')
             packageDestination = getPackageDestination(packageManifest)
         else:
-            raise Exception("Unsupported LPM package type. Cannot install as source.")
+            raise Exception('Unsupported LPM package type. Cannot install as source.')
 
         # Add the new directory to the parent's .pkg as a reference.
         targetAsPackage = ASTools.Package(packageDestination)
@@ -298,7 +326,7 @@ def installSource(package, version, sourceDependencies=None):
         elif packageType in ['program', 'package']:
             packageSourceDependencies = getProgramSourceDependencies(packageSourcePath)
 
-        if (len(packageSourceDependencies) > 0):
+        if len(packageSourceDependencies) > 0:
             # TODO: add support for getting the correct version of these dependencies.
             installPackages(packageSourceDependencies, [''] * len(packageSourceDependencies))
             # Aaand sync those dependencies.
@@ -309,15 +337,18 @@ def installSource(package, version, sourceDependencies=None):
         sourceDependencies = list(set(sourceDependencies))
 
         # save sourceInfo in json
-        sourceInfoFilePath = os.path.join(".", "TempObjects", "sourceInfo.json")
+        sourceInfoFilePath = os.path.join('.', 'TempObjects', 'sourceInfo.json')
         sourceInfo = getJsonData(sourceInfoFilePath)
         sourceInfo[package] = {}
-        sourceInfo[package]["repoPath"] = repoPath
-        sourceInfo[package]["packageSourcePath"] = packageSourcePath
-        sourceInfo[package]['logicalPath'] = os.path.join(packageDestination, os.path.normpath(packageSourcePath).split(os.sep)[-1])
+        sourceInfo[package]['repoPath'] = repoPath
+        sourceInfo[package]['packageSourcePath'] = packageSourcePath
+        sourceInfo[package]['logicalPath'] = os.path.join(
+            packageDestination, os.path.normpath(packageSourcePath).split(os.sep)[-1]
+        )
         saveJsonData(sourceInfo, sourceInfoFilePath)
     except Exception as e:
         raise Exception(f"Error installing source for '{package}': {e}") from e
+
 
 # Get destination of LPM package using manifest, defaulting if unspecified
 def getPackageDestination(packageManifestPath):
@@ -330,17 +361,18 @@ def getPackageDestination(packageManifestPath):
     createPackageTree(packageDestination)
     return packageDestination
 
+
 # Get package source paths from Jenkinsfile
 def getPackageSourcePaths(repoPath):
     jenkinsfilePath = os.path.join(repoPath, 'Jenkinsfile')
     if os.path.exists(jenkinsfilePath):
         with open(jenkinsfilePath) as j:
-            rePackagesToPublishArrayContents = r"packagesToPublish\s*:\s*\[(.*)\]"
+            rePackagesToPublishArrayContents = r'packagesToPublish\s*:\s*\[(.*)\]'
             for line in j:
                 match = re.search(rePackagesToPublishArrayContents, line)
                 if match:
                     arrayContents = match.group(1)
-                    reArrayElement = r"\b[\w\\\/]+\b"
+                    reArrayElement = r'\b[\w\\\/]+\b'
                     matches = re.findall(reArrayElement, arrayContents)
                     packageSourcePaths = []
                     for match in matches:
@@ -351,6 +383,7 @@ def getPackageSourcePaths(repoPath):
         return []
     else:
         return []
+
 
 # Given a repo and a package name, find the package source paths and return the one that either
 #   contains a package.json file with the right "name" value
@@ -363,7 +396,7 @@ def getPackageSourcePathFromRepoPackage(repoPath, packageName: str):
         if os.path.exists(packageJson):
             with open(packageJson) as p:
                 data = json.load(p)
-                if packageName.lower() == data.get("name", "").lower():
+                if packageName.lower() == data.get('name', '').lower():
                     return path
         else:
             splitPath = os.path.normpath(path).split(os.sep)
@@ -398,8 +431,7 @@ def getPackageSourcePathFromRepoPackage(repoPath, packageName: str):
 
     # Check repo root itself first, then recurse into src/source only.
     search_dirs = [repoPath] + [
-        os.path.join(repoPath, d) for d in ('src', 'source')
-        if os.path.isdir(os.path.join(repoPath, d))
+        os.path.join(repoPath, d) for d in ('src', 'source') if os.path.isdir(os.path.join(repoPath, d))
     ]
     for search_dir in search_dirs:
         result = _find_in_tree(search_dir)
@@ -408,8 +440,9 @@ def getPackageSourcePathFromRepoPackage(repoPath, packageName: str):
 
     raise ValueError(
         f"Could not find source path for package '{packageName}' in repo '{repoPath}'. "
-        "No Jenkinsfile packagesToPublish entry and no matching directory found."
+        'No Jenkinsfile packagesToPublish entry and no matching directory found.'
     )
+
 
 def getJsonData(jsonFilePath):
     # Create file only if it doesn't already exist
@@ -428,9 +461,11 @@ def getJsonData(jsonFilePath):
 
     return data
 
+
 def saveJsonData(data: dict, jsonFilePath):
     with open(jsonFilePath, 'w') as fp:
         json.dump(data, fp, indent=2)
+
 
 def openDocumentation(packages):
     command = []
@@ -439,6 +474,7 @@ def openDocumentation(packages):
         command.append(item)
     execute(command, False)
 
+
 def getInfo(package, options):
     command = []
     command.append('npm view')
@@ -446,6 +482,7 @@ def getInfo(package, options):
     for item in options:
         command.append(item)
     execute(command, False)
+
 
 # Create a list of Loupe libraries that are currently in the AS project.
 def readLoupeLibraryList():
@@ -461,13 +498,14 @@ def readLoupeLibraryList():
         return
     return libraryList
 
+
 # Retrieves repo name of a package by fetching data from GitHub
 def getRepoName(package):
     (error, data) = getLoupePackageData(package)
     if error is None:
         fullUrl = data.get('repository', {}).get('html_url', None)
         if fullUrl is None:
-            print("Unable to process package data")
+            print('Unable to process package data')
             return None
         # Return final folder of URL
         repoName = fullUrl.split('/')[-1]
@@ -475,6 +513,7 @@ def getRepoName(package):
     else:
         print(error)
         return None
+
 
 # Retrieve a deep list of all dependencies of the specified packages.
 # This is recursive logic that hurts my brain, but seems to work.
@@ -485,20 +524,24 @@ def getAllDependencies(packages):
         packageManifest = os.path.join('node_modules', package, 'package.json')
         packageType = getPackageManifestField(packageManifest, ['lpm', 'type'])
         # When dealing with an HMI project, don't parse through its dependencies recursively! That gets deep real fast.
-        if(packageType == 'hmi-project'):
+        if packageType == 'hmi-project':
             return packages
         dependencies.append(package)
         # If package.json exists, get dependencies from there.
-        if(os.path.exists(os.path.join('node_modules', package, 'package.json'))):
-            dependencyData = getPackageManifestField(os.path.join('node_modules', package, 'package.json'), ['dependencies'])
-            if(dependencyData is None):
+        if os.path.exists(os.path.join('node_modules', package, 'package.json')):
+            dependencyData = getPackageManifestField(
+                os.path.join('node_modules', package, 'package.json'), ['dependencies']
+            )
+            if dependencyData is None:
                 dependencyData = []
         # If there is no package.json for this package, assume it's a source library, and that it's already sync'd
         # to the Logical View under Libraries / Loupe.
         else:
             # Strip it of its @loupeteam prefix.
             splitPackage = os.path.split(package)[1]
-            dependencyData = getLibrarySourceDependencies(os.path.join('.', 'Logical', 'Libraries', 'Loupe', splitPackage))
+            dependencyData = getLibrarySourceDependencies(
+                os.path.join('.', 'Logical', 'Libraries', 'Loupe', splitPackage)
+            )
             print('Source dependencies: ')
             print(dependencyData)
         localDependencies = []
@@ -512,8 +555,9 @@ def getAllDependencies(packages):
     for dep in dependencies:
         lowerdep = dep.lower()
         if lowerdep not in sanitizedDependencies:
-            sanitizedDependencies.append( lowerdep )
+            sanitizedDependencies.append(lowerdep)
     return sanitizedDependencies
+
 
 def getLibrarySourceDependencies(libraryPath):
     sourceLibrary = ASTools.Library(libraryPath)
@@ -531,6 +575,7 @@ def getLibrarySourceDependencies(libraryPath):
             dependencyNames.append(f'@loupeteam/{dependency.name}'.lower())
     return dependencyNames
 
+
 def getProgramSourceDependencies(programSourcePath):
     dependencyData = getPackageManifestField(os.path.join(programSourcePath, 'package.json'), ['dependencies'])
     dependencyNames = []
@@ -538,6 +583,7 @@ def getProgramSourceDependencies(programSourcePath):
         print('Dependency found: ' + str(key))
         dependencyNames.append(key)
     return dependencyNames
+
 
 # Synchronize a package from the node_modules folder into the appropriate directory.
 def syncPackages(packages):
@@ -551,37 +597,42 @@ def syncPackages(packages):
         packageManifest = os.path.join('node_modules', package, 'package.json')
         packageType = getPackageManifestField(packageManifest, ['lpm', 'type'])
         # Do something different based on package type.
-        if(packageType == 'project'):
+        if packageType == 'project':
             # Copy starter project into root directory.
-            shutil.copytree(os.path.join('node_modules', package), '.', dirs_exist_ok=True, ignore=shutil.ignore_patterns('package.json'))
+            shutil.copytree(
+                os.path.join('node_modules', package),
+                '.',
+                dirs_exist_ok=True,
+                ignore=shutil.ignore_patterns('package.json'),
+            )
 
-        if(packageType == 'hmi-project'):
+        if packageType == 'hmi-project':
             # Copy starter project into root directory.
             shutil.copytree(os.path.join('node_modules', package), '.', dirs_exist_ok=True)
 
-        elif(project is None):
+        elif project is None:
             # Skip sync'ing of other types (packages or libraries) if we're not in a project.
             pass
 
-        elif((packageType == 'program') | (packageType == 'package')):
+        elif (packageType == 'program') | (packageType == 'package'):
             destination = getPackageDestination(packageManifest)
             # Find the module(s) in node_modules, and sync it/them.
             for module in os.listdir(os.path.join('node_modules', '@loupeteam')):
-                if (os.path.join('@loupeteam', module) == os.path.normpath(package)):
+                if os.path.join('@loupeteam', module) == os.path.normpath(package):
                     # Get a handle on the folder destination.
                     destinationPkg = ASTools.Package(destination)
                     # Create a list of filtered objects that don't get copied over.
                     filter = ['package.pkg', 'license', 'readme.md', 'package.json', 'changelog.md']
                     # Loop through all contents in the source directory and copy them over one by one.
                     for item in os.listdir(os.path.join('node_modules', '@loupeteam', module)):
-                        if (item.lower() not in filter):
+                        if item.lower() not in filter:
                             # If the item already exists, delete it.
                             destinationItem = os.path.join(destination, item)
                             if os.path.exists(destinationItem):
                                 destinationPkg.removeObject(item)
                             destinationPkg.addObject(os.path.join('node_modules', package, item))
 
-        elif(packageType == 'library') or (packageType is None):
+        elif (packageType == 'library') or (packageType is None):
             packageDestination = getPackageManifestField(packageManifest, ['lpm', 'logical', 'destination'])
             # If an explicit destination exists, use that. Otherwise default to Logical root.
             if packageDestination is not None:
@@ -592,7 +643,7 @@ def syncPackages(packages):
             createPackageTree(destination)
             # Find the module(s) in node_modules, and sync it/them.
             for module in os.listdir(os.path.join('node_modules', '@loupeteam')):
-                if (os.path.join('@loupeteam', module) == os.path.normpath(package)):
+                if os.path.join('@loupeteam', module) == os.path.normpath(package):
                     # Get a handle on the library's parent folder.
                     parentPkg = ASTools.Package(destination)
                     # If the library already exists, delete it.
@@ -600,6 +651,7 @@ def syncPackages(packages):
                     if os.path.isdir(libraryPath):
                         parentPkg.removeObject(module)
                     parentPkg.addObject(os.path.join('node_modules', package))
+
 
 def deployPackages(config, packages):
     # Figure out where the deployment table is for this configuration.
@@ -609,21 +661,23 @@ def deployPackages(config, packages):
     configPackage = ASTools.CpuConfig(os.path.join('Physical', config, cpuFolderName[0], 'cpu.pkg'))
     for package in packages:
         # Check if the package.json exists in node_modules - if it doesn't, then assume that it is a source library.
-        if(os.path.exists(os.path.join('node_modules', package, 'package.json'))):
+        if os.path.exists(os.path.join('node_modules', package, 'package.json')):
             # Introspect the package.json for this package. Find its 'lpm' section.
             packageManifest = os.path.join('node_modules', package, 'package.json')
             packageType = getPackageManifestField(packageManifest, ['lpm', 'type'])
 
             # Do something different based on package type.
-            if(packageType == 'library') or (packageType is None):
+            if (packageType == 'library') or (packageType is None):
                 libraryLocation = getPackageManifestField(packageManifest, ['lpm', 'logical', 'destination'])
-                if (libraryLocation is None):
+                if libraryLocation is None:
                     libraryLocation = os.path.join('Libraries', 'Loupe')
                 libraryAttributes = getLibraryAttributes(packageManifest, config)
                 # Deploy the required library.
-                deploymentTable.deployLibrary(os.path.join('Logical', libraryLocation), os.path.split(package)[1], libraryAttributes)
+                deploymentTable.deployLibrary(
+                    os.path.join('Logical', libraryLocation), os.path.split(package)[1], libraryAttributes
+                )
 
-            elif((packageType == 'program') | (packageType == 'package')):
+            elif (packageType == 'program') | (packageType == 'package'):
                 cpuDeployment = getPackageManifestField(packageManifest, ['lpm', 'physical', 'cpu'])
                 taskLocation = getPackageDestination(packageManifest)
                 # First deploy all configured tasks.
@@ -632,13 +686,15 @@ def deployPackages(config, packages):
                         deploymentTable.deployTask(taskLocation, item['source'], item['destination'])
                 # Next perform additional configuration changes.
                 # Set the pre-build step if it exists.
-                preBuildCommand = getPackageManifestField(packageManifest, ['lpm', 'physical', 'configuration', 'preBuildStep'])
-                if (preBuildCommand is not None):
+                preBuildCommand = getPackageManifestField(
+                    packageManifest, ['lpm', 'physical', 'configuration', 'preBuildStep']
+                )
+                if preBuildCommand is not None:
                     configPackage.setPreBuildStep(preBuildCommand)
 
         # No package.json is present in node_modules - so it's a source library.
         else:
-            sourceInfoFilePath = os.path.join(".", "TempObjects", "sourceInfo.json")
+            sourceInfoFilePath = os.path.join('.', 'TempObjects', 'sourceInfo.json')
             sourceInfo = getJsonData(sourceInfoFilePath)
             packageSourceInfo = sourceInfo[package]
             packageManifest = os.path.join(packageSourceInfo['packageSourcePath'], 'package.json')
@@ -648,13 +704,17 @@ def deployPackages(config, packages):
                 libraryAttributes = getLibraryAttributes(packageManifest, config)
 
                 # Special case logic: convert AdditionalLibraryDirectories attribute path from logical to actual
-                if "AdditionalLibraryDirectories" in libraryAttributes:
-                    libraryAttributes["AdditionalLibraryDirectories"] = ASTools.getActualPathFromLogicalPath(libraryAttributes["AdditionalLibraryDirectories"])
+                if 'AdditionalLibraryDirectories' in libraryAttributes:
+                    libraryAttributes['AdditionalLibraryDirectories'] = ASTools.getActualPathFromLogicalPath(
+                        libraryAttributes['AdditionalLibraryDirectories']
+                    )
 
                 # Deploy the required library.
-                deploymentTable.deployLibrary(os.path.join('Logical', libraryLocation), os.path.split(package)[1], libraryAttributes)
+                deploymentTable.deployLibrary(
+                    os.path.join('Logical', libraryLocation), os.path.split(package)[1], libraryAttributes
+                )
             elif packageType in ['program', 'package']:
-                sourceInfoFilePath = os.path.join(".", "TempObjects", "sourceInfo.json")
+                sourceInfoFilePath = os.path.join('.', 'TempObjects', 'sourceInfo.json')
                 sourceInfo = getJsonData(sourceInfoFilePath)
                 packageSourceInfo = sourceInfo[package]
                 cpuDeployment = getPackageManifestField(packageManifest, ['lpm', 'physical', 'cpu'])
@@ -665,13 +725,14 @@ def deployPackages(config, packages):
                     for item in cpuDeployment:
                         deploymentTable.deployTask(logicalPackagePath, item['source'], item['destination'])
 
+
 def getLibraryAttributes(packageManifest, config):
     libraryCpus = getPackageManifestField(packageManifest, ['lpm', 'physical', 'cpu'])
     try:
         if isinstance(libraryCpus, list):
             for cpu in libraryCpus:
                 try:
-                    if(cpu['config'].lower() == config.lower()):
+                    if cpu['config'].lower() == config.lower():
                         return cpu['attributes']
                 except Exception:
                     return cpu['attributes']
@@ -684,6 +745,7 @@ def getLibraryAttributes(packageManifest, config):
         return {}
     return {}
 
+
 def createPackageTree(packages: list):
     # Retrieve this as a list of folders for creation.
     normalizedDestination = os.path.normpath(packages)
@@ -691,12 +753,13 @@ def createPackageTree(packages: list):
     for i in range(len(packageList)):
         try:
             # Check for package existence.
-            ASTools.Package(os.path.join(*packageList[:i+1]))
+            ASTools.Package(os.path.join(*packageList[: i + 1]))
         except:
             # Package does not exist, so create it.
             # First retrieve handle of its parent package.
             parentPkg = ASTools.Package(os.path.join(*packageList[:i]))
             parentPkg.addEmptyPackage(packageList[i])
+
 
 def createLibraryManifest(package, lpmConfig):
     library = ASTools.Library('.')
@@ -716,9 +779,9 @@ def createLibraryManifest(package, lpmConfig):
                 version.append(f'<={library._formatVersionString(dependency.maxVersion)}')
             if len(version) == 0:
                 version.append('*')
-            dependency_dict.update({f'@loupeteam/{dependency.name.lower()}':' '.join(version)})
+            dependency_dict.update({f'@loupeteam/{dependency.name.lower()}': ' '.join(version)})
     # Make sure there's a top level description available.
-    if (library.description == ''):
+    if library.description == '':
         description = f"Loupe's {package.lower()} library for Automation Runtime"
     else:
         description = library.description
@@ -727,26 +790,23 @@ def createLibraryManifest(package, lpmConfig):
     # Ensure the lpmConfig has the proper type set.
     try:
         if lpmConfig['type'] != 'library':
-            lpmConfig = { 'type': 'library' }
+            lpmConfig = {'type': 'library'}
     except Exception:
-        lpmConfig = { 'type': 'library' }
+        lpmConfig = {'type': 'library'}
     # Create dictionary that will hold all values for the package.json file
     manifest_dict = {
-                'name': f'@loupeteam/{package.lower()}',
-                'version': library._formatVersionString(library.version),
-                'description': description,
-                'homepage': homepage,
-                'scripts': {},
-                'keywords': [],
-                'author': 'Loupe',
-                'license': 'MIT',
-                'repository': {
-                    'type': 'git',
-                    'url': 'https://github.com/loupeteam/' + package
-                },
-                'lpm': lpmConfig,
-                'dependencies': dependency_dict
-                }
+        'name': f'@loupeteam/{package.lower()}',
+        'version': library._formatVersionString(library.version),
+        'description': description,
+        'homepage': homepage,
+        'scripts': {},
+        'keywords': [],
+        'author': 'Loupe',
+        'license': 'MIT',
+        'repository': {'type': 'git', 'url': 'https://github.com/loupeteam/' + package},
+        'lpm': lpmConfig,
+        'dependencies': dependency_dict,
+    }
     # Convert to JSON and create the file
     manifest_json = json.dumps(manifest_dict, indent=2)
     f = open('.\\package.json', 'w')
@@ -754,11 +814,13 @@ def createLibraryManifest(package, lpmConfig):
     f.close()
     return
 
+
 def getPackageManifestData(manifest):
     f = open(manifest, 'r+', encoding='utf-8')
     data = json.load(f)
     f.close()
     return data
+
 
 def getPackageManifestField(manifest, fieldPath: list):
     data = getPackageManifestData(manifest)
@@ -769,25 +831,27 @@ def getPackageManifestField(manifest, fieldPath: list):
     except:
         return None
 
+
 def setPackageManifestField(manifest, fieldName, fieldData):
     readFile = open(manifest, 'r+')
     data = json.load(readFile)
     readFile.close()
     # If the lpmConfig key isn't in there yet, add it first.
-    if("lpmConfig" not in data):
-        data["lpmConfig"] = {}
-    data["lpmConfig"][fieldName] = fieldData
+    if 'lpmConfig' not in data:
+        data['lpmConfig'] = {}
+    data['lpmConfig'][fieldName] = fieldData
     jsonData = json.dumps(data, indent=2)
     writeFile = open(manifest, 'w')
     writeFile.write(jsonData)
     writeFile.close()
 
+
 def printLoupePackageList():
-    print("Retrieving package data...")
+    print('Retrieving package data...')
     (error, data) = getLoupePackageListData()
 
     if not error:
-        packages_sorted = sorted(data, key=lambda x: x["name"])
+        packages_sorted = sorted(data, key=lambda x: x['name'])
 
         # Pre-process package descriptions; these are handled separately, as they can be None.
         package_descriptions = []
@@ -796,41 +860,50 @@ def printLoupePackageList():
                 if package['repository']['description'] is not None:
                     package_descriptions.append(package['repository']['description'])
                 else:
-                    package_descriptions.append(" ")
+                    package_descriptions.append(' ')
             except:
-                package_descriptions.append(" ")
+                package_descriptions.append(' ')
 
         # Determine column widths.
-        name_col_width = max(len(package["name"]) for package in packages_sorted) + 2
+        name_col_width = max(len(package['name']) for package in packages_sorted) + 2
         version_col_width = 12
         lastmod_col_width = 14
         description_col_width = max(len(description) for description in package_descriptions)
 
         # Print the header.
-        print(  "NAME".ljust(name_col_width) +
-                "VERSIONS".ljust(version_col_width) +
-                "LASTUPDATED".ljust(lastmod_col_width) +
-                "DESCRIPTION".ljust(description_col_width))
-        print(  "----".ljust(name_col_width) +
-                "--------".ljust(version_col_width) +
-                "-----------".ljust(lastmod_col_width) +
-                "-----------".ljust(description_col_width))
+        print(
+            'NAME'.ljust(name_col_width)
+            + 'VERSIONS'.ljust(version_col_width)
+            + 'LASTUPDATED'.ljust(lastmod_col_width)
+            + 'DESCRIPTION'.ljust(description_col_width)
+        )
+        print(
+            '----'.ljust(name_col_width)
+            + '--------'.ljust(version_col_width)
+            + '-----------'.ljust(lastmod_col_width)
+            + '-----------'.ljust(description_col_width)
+        )
 
         for idx, package in enumerate(packages_sorted):
-            print(  package["name"].ljust(name_col_width) +
-                    str(package["version_count"]).ljust(version_col_width) +
-                    package["updated_at"][:10].ljust(lastmod_col_width) +
-                    package_descriptions[idx].ljust(description_col_width))
+            print(
+                package['name'].ljust(name_col_width)
+                + str(package['version_count']).ljust(version_col_width)
+                + package['updated_at'][:10].ljust(lastmod_col_width)
+                + package_descriptions[idx].ljust(description_col_width)
+            )
     else:
-        print(f"Unable to print package list: {error}")
+        print(f'Unable to print package list: {error}')
+
 
 # Fetches data using GitHub API (See https://docs.github.com/en/rest/packages?apiVersion=2022-11-28#list-packages-for-an-organization)
 # Returns (error, data) tuple, where error is None if all OK and data is a list of package dictionaries (see GitHub's schema)
 def getLoupePackageListData():
     token = getLocalToken()
-    headers = { 'Authorization': f'Bearer {token}',
-                'Accept': 'application/vnd.github+json',
-                'X-GitHub-Api-Version': '2022-11-28' }
+    headers = {
+        'Authorization': f'Bearer {token}',
+        'Accept': 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+    }
     organization = 'loupeteam'
     page = 1
     per_page = 100
@@ -838,37 +911,45 @@ def getLoupePackageListData():
     all_packages = []
 
     while not all_packages_gathered:
-        params = {  'package_type': 'npm',
-                    'page': str(page),
-                    'per_page': str(per_page) }
-        r = requests.get(f'https://api.github.com/orgs/{organization}/packages', headers=headers, params=params, timeout=5)
+        params = {'package_type': 'npm', 'page': str(page), 'per_page': str(per_page)}
+        r = requests.get(
+            f'https://api.github.com/orgs/{organization}/packages', headers=headers, params=params, timeout=5
+        )
         if r.status_code != 200:
-            error = "Status code not OK. Code: " + str(r.status_code) + "\n" + r.text
+            error = 'Status code not OK. Code: ' + str(r.status_code) + '\n' + r.text
             return (error, [])  # Early return
         retrieved_packages = json.loads(r.content)
         all_packages += retrieved_packages
-        all_packages_gathered = len(retrieved_packages) < per_page    # All gathered once there are fewer results than full amount
+        all_packages_gathered = (
+            len(retrieved_packages) < per_page
+        )  # All gathered once there are fewer results than full amount
         page += 1
 
-    print(f"Retrieved {len(all_packages)} packages total. See below for detailed information.")
+    print(f'Retrieved {len(all_packages)} packages total. See below for detailed information.')
     return (None, all_packages)
+
 
 # Fetches data using GitHub API (See https://docs.github.com/en/rest/packages?apiVersion=2022-11-28#list-packages-for-an-organization)
 # Returns (error, data) tuple, where error is None if all OK and data is a dictionary of the desired package (see GitHub's schema)
 def getLoupePackageData(packageName: str):
     token = getLocalToken()
-    headers = { 'Authorization': f'Bearer {token}',
-                'Accept': 'application/vnd.github+json',
-                'X-GitHub-Api-Version': '2022-11-28' }
+    headers = {
+        'Authorization': f'Bearer {token}',
+        'Accept': 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+    }
     organization = 'loupeteam'
 
-    packageNameStripped = os.path.split(packageName)[1] # Strip it of its @loupeteam prefix.
-    r = requests.get(f'https://api.github.com/orgs/{organization}/packages/npm/{packageNameStripped}', headers=headers, timeout=5)
+    packageNameStripped = os.path.split(packageName)[1]  # Strip it of its @loupeteam prefix.
+    r = requests.get(
+        f'https://api.github.com/orgs/{organization}/packages/npm/{packageNameStripped}', headers=headers, timeout=5
+    )
     if r.status_code != 200:
-        error = "Status code not OK. Code: " + str(r.status_code) + "\n" + r.text
+        error = 'Status code not OK. Code: ' + str(r.status_code) + '\n' + r.text
         return (error, [])  # Early return
     packageData = json.loads(r.content)
     return (None, packageData)
+
 
 # Run a generic NPM command on the specified packages.
 def runGenericNpmCmd(cmd, packages):
@@ -879,43 +960,50 @@ def runGenericNpmCmd(cmd, packages):
         command.append(item)
     execute(command, False)
 
+
 # Execute a generic batch script command.
 def execute(cmd, quiet):
-    #process = subprocess.Popen(' '.join(cmd), encoding="utf-8", errors='replace', shell=True)
-    process = subprocess.Popen(' '.join(cmd), stdout=subprocess.PIPE, encoding="utf-8", errors='replace', shell=True)
+    # process = subprocess.Popen(' '.join(cmd), encoding="utf-8", errors='replace', shell=True)
+    process = subprocess.Popen(' '.join(cmd), stdout=subprocess.PIPE, encoding='utf-8', errors='replace', shell=True)
     while process.returncode is None:
         rawStdOut = process.stdout.readline()
-        #rawStdErr = process.stderr.readline()
+        # rawStdErr = process.stderr.readline()
         strippedStdOut = rawStdOut.rstrip()
-        #strippedStdErr = rawStdErr#.rstrip()
-        if (not quiet):
-            if (strippedStdOut != ''):
+        # strippedStdErr = rawStdErr#.rstrip()
+        if not quiet:
+            if strippedStdOut != '':
                 print(strippedStdOut)
             # if (strippedStdErr != ''):
             #     cprint(strippedStdErr, 'red')
         process.poll()
-    if (process.returncode != 0):
+    if process.returncode != 0:
         raise Exception('Error during process execution')
+
 
 def executeStandard(cmd):
-    process = subprocess.Popen(' '.join(cmd), encoding="utf-8", errors='replace', shell=True)
+    process = subprocess.Popen(' '.join(cmd), encoding='utf-8', errors='replace', shell=True)
     while process.returncode is None:
         process.poll()
-    if (process.returncode != 0):
+    if process.returncode != 0:
         raise Exception('Error during process execution')
 
+
 def executeAndContinue(cmd):
-    subprocess.Popen(' '.join(cmd), encoding="utf-8", errors='replace', shell=True)
+    subprocess.Popen(' '.join(cmd), encoding='utf-8', errors='replace', shell=True)
     return
 
+
 def executeAndReturnCode(cmd):
-    process = subprocess.Popen(' '.join(cmd), encoding="utf-8", stdout=subprocess.PIPE, stderr=subprocess.PIPE, errors='replace', shell=True)
+    process = subprocess.Popen(
+        ' '.join(cmd), encoding='utf-8', stdout=subprocess.PIPE, stderr=subprocess.PIPE, errors='replace', shell=True
+    )
     while process.returncode is None:
         process.poll()
     return process.returncode
 
+
 def executeAndReturnStdOut(cmd):
-    process = subprocess.Popen(' '.join(cmd), stdout=subprocess.PIPE, encoding="utf-8", errors='replace', shell=True)
+    process = subprocess.Popen(' '.join(cmd), stdout=subprocess.PIPE, encoding='utf-8', errors='replace', shell=True)
     std_out = ''
     while process.returncode is None:
         rawStdOut = process.stdout.readline()

--- a/src/lpm_core.py
+++ b/src/lpm_core.py
@@ -20,10 +20,9 @@ import re
 import shutil
 import subprocess
 
+import aspython as ASTools
 import requests
 from termcolor import colored, cprint
-
-import aspython as ASTools
 
 
 def isAuthenticated():

--- a/src/lpm_core.py
+++ b/src/lpm_core.py
@@ -4,8 +4,7 @@
  * https://loupe.team
  *
  * This file is part of LPM, licensed under the MIT License.
-'''
-'''
+
 LPM core functionality.
 
 This module contains the underlying package-management, authentication, manifest
@@ -14,15 +13,14 @@ LPM.py and is responsible for argument parsing and user-facing output;
 everything else lives here so it can be reused and tested in isolation.
 '''
 
+import json
 import os
 import os.path
-import json
+import re
 import shutil
 import subprocess
-import sys
-import re
-import requests
 
+import requests
 from termcolor import colored, cprint
 
 import aspython as ASTools
@@ -71,7 +69,6 @@ def importLibraries():
     try:
         loupePkg = ASTools.Package('./Logical/Libraries/Loupe')
     except:
-        err = sys.exc_info()
         print('Loupe folder not found, trying _ARG...')
         try:
             loupePkg = ASTools.Package('./Logical/Libraries/_ARG')
@@ -137,13 +134,14 @@ def configureProject(args):
         print('Configuration options are only supported at the root level of a project')
         return
     deploymentConfigs = getPackageManifestField('package.json', ['lpmConfig', 'deploymentConfigs'])
-    if(deploymentConfigs == None): deploymentConfigs = []
+    if deploymentConfigs is None:
+        deploymentConfigs = []
     if (args.nocolor) or (args.silent):
         print('Support for interactive prompts is disabled. Default values will be assigned to the package.json file.')
         print('All configurations in the project are being assigned as deployment targets: ' + ' '.join(project.buildConfigNames))
         setPackageManifestField('package.json', 'deploymentConfigs', project.buildConfigNames)
     else:
-        from InquirerPy import inquirer, get_style
+        from InquirerPy import get_style, inquirer
         from InquirerPy.base.control import Choice
 
         # Config question #1: Deployment configurations.
@@ -170,7 +168,8 @@ def configureProject(args):
         # Config question #2: Configure a Git client.
         # Check to see if there already is a configuration, and if so display that.
         gitClient = getPackageManifestField('package.json', ['lpmConfig', 'gitClient'])
-        if(gitClient == None): gitClient = ''
+        if gitClient is None:
+            gitClient = ''
         availableClients = ['GitExtensions', 'GitKraken', 'SourceTree', ''] # Note that these are available but not all supported (=
         configOptions = []
         for client in availableClients:
@@ -199,22 +198,22 @@ def getPackageType(path):
         # First check for the lpm->type metadata.
         packageType = getPackageManifestField(manifestFilePath, ['lpm', 'type'])
     # If the field is not present, or the file is not present, then search manually for an indicative file extension.
-    if (packageType == None):
+    if (packageType is None):
         try:
-            project = ASTools.Project(path)
+            ASTools.Project(path)
             packageType = 'project'
         except:
             try:
-                library = ASTools.Library(path)
+                ASTools.Library(path)
                 packageType = 'library'
             except:
                 try:
-                    package = ASTools.Package(path)
+                    ASTools.Package(path)
                     packageType = 'program'
                 except:
                     # Getting here means no matches were found.
                     packageType = None
-    if packageType == None:
+    if packageType is None:
         return 'undefined'
     else:
         return packageType
@@ -324,7 +323,7 @@ def installSource(package, version, sourceDependencies=None):
 def getPackageDestination(packageManifestPath):
     manifestPackageDestination = getPackageManifestField(packageManifestPath, ['lpm', 'logical', 'destination'])
     # If an explicit destination exists, use that. Otherwise default to Logical root.
-    if manifestPackageDestination != None:
+    if manifestPackageDestination is not None:
         packageDestination = os.path.join('Logical', manifestPackageDestination)
     else:
         packageDestination = 'Logical'
@@ -492,7 +491,7 @@ def getAllDependencies(packages):
         # If package.json exists, get dependencies from there.
         if(os.path.exists(os.path.join('node_modules', package, 'package.json'))):
             dependencyData = getPackageManifestField(os.path.join('node_modules', package, 'package.json'), ['dependencies'])
-            if(dependencyData == None):
+            if(dependencyData is None):
                 dependencyData = []
         # If there is no package.json for this package, assume it's a source library, and that it's already sync'd
         # to the Logical View under Libraries / Loupe.
@@ -560,7 +559,7 @@ def syncPackages(packages):
             # Copy starter project into root directory.
             shutil.copytree(os.path.join('node_modules', package), '.', dirs_exist_ok=True)
 
-        elif(project == None):
+        elif(project is None):
             # Skip sync'ing of other types (packages or libraries) if we're not in a project.
             pass
 
@@ -582,10 +581,10 @@ def syncPackages(packages):
                                 destinationPkg.removeObject(item)
                             destinationPkg.addObject(os.path.join('node_modules', package, item))
 
-        elif(packageType == 'library') or (packageType == None):
+        elif(packageType == 'library') or (packageType is None):
             packageDestination = getPackageManifestField(packageManifest, ['lpm', 'logical', 'destination'])
             # If an explicit destination exists, use that. Otherwise default to Logical root.
-            if packageDestination != None:
+            if packageDestination is not None:
                 destination = os.path.join('Logical', packageDestination)
             else:
                 destination = os.path.join('Logical', 'Libraries', 'Loupe')
@@ -616,9 +615,9 @@ def deployPackages(config, packages):
             packageType = getPackageManifestField(packageManifest, ['lpm', 'type'])
 
             # Do something different based on package type.
-            if(packageType == 'library') or (packageType == None):
+            if(packageType == 'library') or (packageType is None):
                 libraryLocation = getPackageManifestField(packageManifest, ['lpm', 'logical', 'destination'])
-                if (libraryLocation == None):
+                if (libraryLocation is None):
                     libraryLocation = os.path.join('Libraries', 'Loupe')
                 libraryAttributes = getLibraryAttributes(packageManifest, config)
                 # Deploy the required library.
@@ -628,13 +627,13 @@ def deployPackages(config, packages):
                 cpuDeployment = getPackageManifestField(packageManifest, ['lpm', 'physical', 'cpu'])
                 taskLocation = getPackageDestination(packageManifest)
                 # First deploy all configured tasks.
-                if cpuDeployment != None:
+                if cpuDeployment is not None:
                     for item in cpuDeployment:
                         deploymentTable.deployTask(taskLocation, item['source'], item['destination'])
                 # Next perform additional configuration changes.
                 # Set the pre-build step if it exists.
                 preBuildCommand = getPackageManifestField(packageManifest, ['lpm', 'physical', 'configuration', 'preBuildStep'])
-                if (preBuildCommand != None):
+                if (preBuildCommand is not None):
                     configPackage.setPreBuildStep(preBuildCommand)
 
         # No package.json is present in node_modules - so it's a source library.
@@ -662,26 +661,26 @@ def deployPackages(config, packages):
 
                 logicalPackagePath = os.path.normpath(packageSourceInfo['logicalPath'])
 
-                if cpuDeployment != None:
+                if cpuDeployment is not None:
                     for item in cpuDeployment:
                         deploymentTable.deployTask(logicalPackagePath, item['source'], item['destination'])
 
 def getLibraryAttributes(packageManifest, config):
     libraryCpus = getPackageManifestField(packageManifest, ['lpm', 'physical', 'cpu'])
     try:
-        if (type(libraryCpus) == list):
+        if isinstance(libraryCpus, list):
             for cpu in libraryCpus:
                 try:
                     if(cpu['config'].lower() == config.lower()):
                         return cpu['attributes']
-                except Exception as e:
+                except Exception:
                     return cpu['attributes']
         else:
             try:
                 return libraryCpus['attributes']
-            except Exception as e:
+            except Exception:
                 return {}
-    except Exception as e:
+    except Exception:
         return {}
     return {}
 
@@ -692,12 +691,12 @@ def createPackageTree(packages: list):
     for i in range(len(packageList)):
         try:
             # Check for package existence.
-            pkg = ASTools.Package(os.path.join(*packageList[:i+1]))
+            ASTools.Package(os.path.join(*packageList[:i+1]))
         except:
             # Package does not exist, so create it.
             # First retrieve handle of its parent package.
             parentPkg = ASTools.Package(os.path.join(*packageList[:i]))
-            pkg = parentPkg.addEmptyPackage(packageList[i])
+            parentPkg.addEmptyPackage(packageList[i])
 
 def createLibraryManifest(package, lpmConfig):
     library = ASTools.Library('.')
@@ -775,7 +774,7 @@ def setPackageManifestField(manifest, fieldName, fieldData):
     data = json.load(readFile)
     readFile.close()
     # If the lpmConfig key isn't in there yet, add it first.
-    if(not "lpmConfig" in data):
+    if("lpmConfig" not in data):
         data["lpmConfig"] = {}
     data["lpmConfig"][fieldName] = fieldData
     jsonData = json.dumps(data, indent=2)
@@ -884,7 +883,7 @@ def runGenericNpmCmd(cmd, packages):
 def execute(cmd, quiet):
     #process = subprocess.Popen(' '.join(cmd), encoding="utf-8", errors='replace', shell=True)
     process = subprocess.Popen(' '.join(cmd), stdout=subprocess.PIPE, encoding="utf-8", errors='replace', shell=True)
-    while process.returncode == None:
+    while process.returncode is None:
         rawStdOut = process.stdout.readline()
         #rawStdErr = process.stderr.readline()
         strippedStdOut = rawStdOut.rstrip()
@@ -900,25 +899,25 @@ def execute(cmd, quiet):
 
 def executeStandard(cmd):
     process = subprocess.Popen(' '.join(cmd), encoding="utf-8", errors='replace', shell=True)
-    while process.returncode == None:
+    while process.returncode is None:
         process.poll()
     if (process.returncode != 0):
         raise Exception('Error during process execution')
 
 def executeAndContinue(cmd):
-    process = subprocess.Popen(' '.join(cmd), encoding="utf-8", errors='replace', shell=True)
+    subprocess.Popen(' '.join(cmd), encoding="utf-8", errors='replace', shell=True)
     return
 
 def executeAndReturnCode(cmd):
     process = subprocess.Popen(' '.join(cmd), encoding="utf-8", stdout=subprocess.PIPE, stderr=subprocess.PIPE, errors='replace', shell=True)
-    while process.returncode == None:
+    while process.returncode is None:
         process.poll()
     return process.returncode
 
 def executeAndReturnStdOut(cmd):
     process = subprocess.Popen(' '.join(cmd), stdout=subprocess.PIPE, encoding="utf-8", errors='replace', shell=True)
     std_out = ''
-    while process.returncode == None:
+    while process.returncode is None:
         rawStdOut = process.stdout.readline()
         strippedStdOut = rawStdOut.rstrip()
         std_out = std_out + strippedStdOut

--- a/test/test_lpm.py
+++ b/test/test_lpm.py
@@ -7,17 +7,17 @@ from datetime import datetime
 
 import pytest
 
-sys.path.insert(0, "./src")
+sys.path.insert(0, './src')
 import LPM
 
-sys.path.insert(0, "./src/ASPython")
+sys.path.insert(0, './src/ASPython')
 import ASTools
 
-LPM_AS_TEMPLATE_FOLDER_NAME = "asproject_template_librarybuilderproject"
-LPM_AS_TEMPLATE_PATH = os.path.join("./test/", LPM_AS_TEMPLATE_FOLDER_NAME)
+LPM_AS_TEMPLATE_FOLDER_NAME = 'asproject_template_librarybuilderproject'
+LPM_AS_TEMPLATE_PATH = os.path.join('./test/', LPM_AS_TEMPLATE_FOLDER_NAME)
+
 
 class TestLpm:
-    
     @classmethod
     def setup_class(cls):
         # Code to run before each test method
@@ -27,44 +27,44 @@ class TestLpm:
 
         # create temporary folder
         now = datetime.now()
-        timestamp = now.strftime("%y%m%d-%H-%M-%S")
+        timestamp = now.strftime('%y%m%d-%H-%M-%S')
         test_folder = timestamp
-        cls.test_dir = os.path.join("./temp/", test_folder)
+        cls.test_dir = os.path.join('./temp/', test_folder)
 
         # Source directory
         asproject_template_source = LPM_AS_TEMPLATE_PATH
 
         # Copy the entire directory tree, allowing existing destination
         shutil.copytree(asproject_template_source, cls.test_dir, dirs_exist_ok=True)
-        print(f"Copied template to test folder: {cls.test_dir}")
+        print(f'Copied template to test folder: {cls.test_dir}')
 
     @classmethod
     def teardown_class(cls):
         # Code to run after each test method
 
         # shutil.rmtree(cls.test_dir)
-        print("Teardown code")
-    
+        print('Teardown code')
+
     @classmethod
     def ensure_as_template_exists(cls):
-        
+
         # ensure template folder exists
         if not os.path.exists(LPM_AS_TEMPLATE_PATH):
             os.mkdir(LPM_AS_TEMPLATE_PATH)
-        
-        # determine if already set up with library bulder project 
+
+        # determine if already set up with library bulder project
         try:
-            with open(os.path.join(LPM_AS_TEMPLATE_PATH, "package.json")) as p:
+            with open(os.path.join(LPM_AS_TEMPLATE_PATH, 'package.json')) as p:
                 package_dict = json.load(p)
-                if "@loupeteam/librarybuilderproject" in package_dict["dependencies"]:
+                if '@loupeteam/librarybuilderproject' in package_dict['dependencies']:
                     template_reinit_required = False
                 else:
                     template_reinit_required = True
         except:
             template_reinit_required = True
-        
+
         if template_reinit_required:
-            print("No template found. Creating...")
+            print('No template found. Creating...')
 
             # delete everything inside the template folder, if any (to start afresh)
             for filename in os.listdir(LPM_AS_TEMPLATE_PATH):
@@ -79,84 +79,84 @@ class TestLpm:
 
             monkeypatch = pytest.MonkeyPatch()
 
-            # lpm init        
+            # lpm init
             monkeypatch.chdir(path=LPM_AS_TEMPLATE_PATH)
-            monkeypatch.setattr(sys, "argv", ["lpm.py", "--silent", "init"])
+            monkeypatch.setattr(sys, 'argv', ['lpm.py', '--silent', 'init'])
             LPM.main()
 
             # lpm install library builder project
-            monkeypatch.setattr(sys, "argv", ["lpm.py", "--silent", "install", "librarybuilderproject"])
+            monkeypatch.setattr(sys, 'argv', ['lpm.py', '--silent', 'install', 'librarybuilderproject'])
             LPM.main()
-            
+
             monkeypatch.undo()
-            
+
             # Manually modify package.json (avoid dealing with console prompting with "lpm configure")
-            with open(os.path.join(LPM_AS_TEMPLATE_PATH, "package.json"), 'r') as p:
+            with open(os.path.join(LPM_AS_TEMPLATE_PATH, 'package.json'), 'r') as p:
                 package_dict = json.load(p)
-            package_dict["lpmConfig"] = {"deploymentConfigs": ["Intel", "Arm"], "gitClient": "GitExtensions"}
-            with open(os.path.join(LPM_AS_TEMPLATE_PATH, "package.json"), 'w') as p:
+            package_dict['lpmConfig'] = {'deploymentConfigs': ['Intel', 'Arm'], 'gitClient': 'GitExtensions'}
+            with open(os.path.join(LPM_AS_TEMPLATE_PATH, 'package.json'), 'w') as p:
                 json.dump(package_dict, p, indent=2)
 
-            print("Template creation complete.")
+            print('Template creation complete.')
 
         else:
-            print("Template found. No need to (re)create.")
+            print('Template found. No need to (re)create.')
 
     def test_version(self, capsys, monkeypatch):
 
         # argparse will exit from within for version, so we need the pytest context manager
         with pytest.raises(SystemExit):
-            monkeypatch.setattr(sys, "argv", ["lpm.py", "-v"])
+            monkeypatch.setattr(sys, 'argv', ['lpm.py', '-v'])
             LPM.main()
-        
+
         # Verify output
         captured = capsys.readouterr()
-        version_output = re.fullmatch(r"LPM: \d+\.\d+\.\d+[^\n]*\n", captured.out)
+        version_output = re.fullmatch(r'LPM: \d+\.\d+\.\d+[^\n]*\n', captured.out)
         assert version_output is not None
 
     def test_hoist_silent_after_subcommand(self):
         """--silent placed after the subcommand should be accepted, not error."""
-        hoisted = LPM._hoist_global_flags(["install", "--silent"])
-        assert hoisted == ["--silent", "install"]
+        hoisted = LPM._hoist_global_flags(['install', '--silent'])
+        assert hoisted == ['--silent', 'install']
 
     def test_hoist_silent_after_subcommand_with_package(self):
         """--silent placed after packages should be hoisted before the subcommand."""
-        hoisted = LPM._hoist_global_flags(["install", "somepkg", "--silent"])
-        assert hoisted == ["--silent", "install", "somepkg"]
+        hoisted = LPM._hoist_global_flags(['install', 'somepkg', '--silent'])
+        assert hoisted == ['--silent', 'install', 'somepkg']
 
     def test_hoist_nocolor_after_subcommand(self):
         """-nc/--nocolor placed after the subcommand should be hoisted."""
-        hoisted = LPM._hoist_global_flags(["install", "somepkg", "--nocolor"])
-        assert hoisted == ["--nocolor", "install", "somepkg"]
+        hoisted = LPM._hoist_global_flags(['install', 'somepkg', '--nocolor'])
+        assert hoisted == ['--nocolor', 'install', 'somepkg']
 
     def test_hoist_flag_before_subcommand_unchanged(self):
         """Flags already before the subcommand should not be moved."""
-        hoisted = LPM._hoist_global_flags(["--silent", "install", "somepkg"])
-        assert hoisted == ["--silent", "install", "somepkg"]
+        hoisted = LPM._hoist_global_flags(['--silent', 'install', 'somepkg'])
+        assert hoisted == ['--silent', 'install', 'somepkg']
 
     def test_hoist_parse_silent_after_subcommand(self, monkeypatch):
         """lpm install --silent should parse without error and set silent=True."""
-        monkeypatch.setattr(sys, "argv", ["lpm.py", "install", "--silent"])
+        monkeypatch.setattr(sys, 'argv', ['lpm.py', 'install', '--silent'])
         monkeypatch.chdir(self.test_dir)
         try:
-            parser, sub = LPM._build_parser("LPM")
-            raw_args = LPM._hoist_global_flags(["install", "--silent"])
+            parser, sub = LPM._build_parser('LPM')
+            raw_args = LPM._hoist_global_flags(['install', '--silent'])
             ns = parser.parse_args(raw_args)
             assert ns.silent is True
-            assert ns.cmd == "install"
+            assert ns.cmd == 'install'
         finally:
             monkeypatch.undo()
 
     # Prior to installing atn, install 1 of 3 dependencies
     def test_stringext_install(self, monkeypatch):
-        monkeypatch.setattr(sys, "argv", ["lpm.py", "install", "stringext"])
+        monkeypatch.setattr(sys, 'argv', ['lpm.py', 'install', 'stringext'])
         monkeypatch.chdir(self.test_dir)
         try:
             LPM.main()
 
-            with open("package.json") as p:
+            with open('package.json') as p:
                 package_dict = json.load(p)
-                assert "@loupeteam/stringext" in package_dict["dependencies"]
+                assert '@loupeteam/stringext' in package_dict['dependencies']
         finally:
             monkeypatch.undo()
 
@@ -166,70 +166,70 @@ class TestLpm:
 
         try:
             # Attempt invalid version
-            version_invalid = "0.99.9"
-            monkeypatch.setattr(sys, "argv", ["lpm.py", "install", f"vartools@{version_invalid}"])
+            version_invalid = '0.99.9'
+            monkeypatch.setattr(sys, 'argv', ['lpm.py', 'install', f'vartools@{version_invalid}'])
 
             LPM.main()
             captured = capsys.readouterr()
-            
+
             print(captured.out)
-            err_match = re.search(r"Error while attempting to install package", captured.out)
+            err_match = re.search(r'Error while attempting to install package', captured.out)
             assert err_match is not None
 
             # Attempt valid version
-            version_valid = "0.11.3"
-            monkeypatch.setattr(sys, "argv", ["lpm.py", "install", f"vartools@{version_valid}"])
-        
+            version_valid = '0.11.3'
+            monkeypatch.setattr(sys, 'argv', ['lpm.py', 'install', f'vartools@{version_valid}'])
+
             LPM.main()
 
-            with open("package.json") as p:
+            with open('package.json') as p:
                 package_dict = json.load(p)
-                assert "@loupeteam/vartools" in package_dict["dependencies"]
-                assert version_valid in package_dict["dependencies"]["@loupeteam/vartools"]
-        
+                assert '@loupeteam/vartools' in package_dict['dependencies']
+                assert version_valid in package_dict['dependencies']['@loupeteam/vartools']
+
         finally:
             monkeypatch.undo()
 
     def test_atn_install_as_src(self, monkeypatch):
-        monkeypatch.setattr(sys, "argv", ["lpm.py", "install", "atn", "-src"])
+        monkeypatch.setattr(sys, 'argv', ['lpm.py', 'install', 'atn', '-src'])
         monkeypatch.chdir(self.test_dir)
         try:
             LPM.main()
 
-            source_info_path = os.path.join(".", "TempObjects", "sourceInfo.json")
+            source_info_path = os.path.join('.', 'TempObjects', 'sourceInfo.json')
             assert os.path.exists(source_info_path)
-            
+
             with open(source_info_path) as s:
                 source_info_dict = json.load(s)
-                assert "@loupeteam/atn" in source_info_dict
+                assert '@loupeteam/atn' in source_info_dict
         finally:
             monkeypatch.undo()
 
     def test_revinfoprog_install_as_src(self, monkeypatch):
-        monkeypatch.setattr(sys, "argv", ["lpm.py", "install", "revinfoprog", "--source"])
+        monkeypatch.setattr(sys, 'argv', ['lpm.py', 'install', 'revinfoprog', '--source'])
         monkeypatch.chdir(self.test_dir)
         try:
             LPM.main()
-            
-            source_info_path = os.path.join(".", "TempObjects", "sourceInfo.json")
+
+            source_info_path = os.path.join('.', 'TempObjects', 'sourceInfo.json')
             assert os.path.exists(source_info_path)
-            
+
             with open(source_info_path) as s:
                 source_info_dict = json.load(s)
-                assert "@loupeteam/revinfoprog" in source_info_dict
+                assert '@loupeteam/revinfoprog' in source_info_dict
         finally:
             monkeypatch.undo()
 
     # Install a representative program (not as source)
     def test_luxprog_install(self, monkeypatch):
-        monkeypatch.setattr(sys, "argv", ["lpm.py", "install", "luxprog"])
+        monkeypatch.setattr(sys, 'argv', ['lpm.py', 'install', 'luxprog'])
         monkeypatch.chdir(self.test_dir)
         try:
             LPM.main()
 
-            with open("package.json") as p:
+            with open('package.json') as p:
                 package_dict = json.load(p)
-                assert "@loupeteam/luxprog" in package_dict["dependencies"]
+                assert '@loupeteam/luxprog' in package_dict['dependencies']
         finally:
             monkeypatch.undo()
 
@@ -238,38 +238,40 @@ class TestLpm:
         monkeypatch.chdir(self.test_dir)
         try:
             # Pre-condition: package.json must already have dependencies (added by prior install tests).
-            with open("package.json") as p:
+            with open('package.json') as p:
                 package_dict = json.load(p)
-            deps = package_dict.get("dependencies", {})
-            assert deps, "Pre-condition: package.json must have dependencies"
+            deps = package_dict.get('dependencies', {})
+            assert deps, 'Pre-condition: package.json must have dependencies'
 
             from unittest.mock import patch
 
-            with patch("LPM.installPackages"), \
-                 patch("LPM.getAllDependencies", return_value=list(deps.keys())) as mock_get_all_deps, \
-                 patch("LPM.syncPackages") as mock_sync, \
-                 patch("LPM.deployPackages") as mock_deploy:
-                monkeypatch.setattr(sys, "argv", ["lpm.py", "install"])
+            with (
+                patch('LPM.installPackages'),
+                patch('LPM.getAllDependencies', return_value=list(deps.keys())) as mock_get_all_deps,
+                patch('LPM.syncPackages') as mock_sync,
+                patch('LPM.deployPackages') as mock_deploy,
+            ):
+                monkeypatch.setattr(sys, 'argv', ['lpm.py', 'install'])
                 LPM.main()
 
             # getAllDependencies must have been called with the resolved package list,
             # not an empty list (which would make sync/deploy a no-op – the original bug).
-            assert mock_get_all_deps.called, "getAllDependencies was not called"
+            assert mock_get_all_deps.called, 'getAllDependencies was not called'
             call_packages = mock_get_all_deps.call_args_list[0][0][0]
             assert len(call_packages) > 0, (
-                "getAllDependencies was called with an empty list; "
-                "sync/deploy would be a no-op (regression of the no-args install bug)"
+                'getAllDependencies was called with an empty list; '
+                'sync/deploy would be a no-op (regression of the no-args install bug)'
             )
-            assert mock_sync.called, "syncPackages was not called"
-            assert mock_deploy.called, "deployPackages was not called"
+            assert mock_sync.called, 'syncPackages was not called'
+            assert mock_deploy.called, 'deployPackages was not called'
         finally:
             monkeypatch.undo()
 
     def test_build_intel(self, monkeypatch):
         monkeypatch.chdir(self.test_dir)
         try:
-            project = ASTools.Project(".")
-            build_result = project.build("Intel")
+            project = ASTools.Project('.')
+            build_result = project.build('Intel')
             assert build_result.returncode == 0 or build_result.returncode == 1  # 0: no issues, 1: warnings only
         finally:
             monkeypatch.undo()
@@ -277,14 +279,8 @@ class TestLpm:
     def test_build_arm(self, monkeypatch):
         monkeypatch.chdir(self.test_dir)
         try:
-            project = ASTools.Project(".")
-            build_result = project.build("Arm")
+            project = ASTools.Project('.')
+            build_result = project.build('Arm')
             assert build_result.returncode == 0 or build_result.returncode == 1  # 0: no issues, 1: warnings only
         finally:
             monkeypatch.undo()
-
-
-
-
-
-

--- a/test/test_lpm.py
+++ b/test/test_lpm.py
@@ -1,18 +1,17 @@
-import pytest
+import json
 import os
-import sys
-from datetime import datetime
 import re
 import shutil
-import json
+import sys
+from datetime import datetime
+
+import pytest
 
 sys.path.insert(0, "./src")
 import LPM
 
-
 sys.path.insert(0, "./src/ASPython")
 import ASTools
-
 
 LPM_AS_TEMPLATE_FOLDER_NAME = "asproject_template_librarybuilderproject"
 LPM_AS_TEMPLATE_PATH = os.path.join("./test/", LPM_AS_TEMPLATE_FOLDER_NAME)


### PR DESCRIPTION
## Summary

- Adds Ruff (`v0.15.12`, pinned) as a CI lint/format gate via a new `lint` job in `.github/workflows/ci.yml` (runs on `ubuntu-latest`).
- Configures Ruff via a new `pyproject.toml`: line-length 120, rules `E,W,F,I`, single-quote format style, and `src/ASPython` (submodule) excluded.
- Cleans up the lint violations that aren't deferred via ignores: imports moved to top of files, unused locals dropped, `== None`/`type(...) ==` modernized, etc.
- Applies an initial `ruff format` pass as a separate commit so config and formatting churn are reviewable independently.

## Deferred (with TODOs in `pyproject.toml`)

- `E722` (bare `except:`) — globally ignored. Real cleanup tracked.
- `E501` (line-too-long) — globally ignored after bumping line-length to 120; ~26 long user-facing prompt strings remain. Tracked as TODO to wrap and re-enable.
- `F403` / `F405` — per-file ignored in `src/LPM.py` because of `from lpm_core import *`. TODO to convert to explicit imports.

## Test plan

- [x] CI `lint` job passes on this branch.
- [x] CI `test` job still passes (no behavioral changes — format and import-shuffle only).
- [ ] Local `ruff check .` and `ruff format --check .` both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)