### PR TITLE
fix: cleanup from #60 Copilot review

### DIFF
--- a/src/lpm_core.py
+++ b/src/lpm_core.py
@@ -50,9 +50,13 @@ def getAuthenticatedUser():
 
 def getLocalToken():
     # Search in the local .npmrc file for this token.
-    f = open(os.path.join(os.path.expanduser('~'), '.npmrc'), 'r')
-    text = f.readlines()
-    return re.search('_authToken=(.+)', '\n'.join(text)).group(1)
+    npmrcPath = os.path.join(os.path.expanduser('~'), '.npmrc')
+    with open(npmrcPath, 'r') as f:
+        text = f.readlines()
+    match = re.search('_authToken=(.+)', '\n'.join(text))
+    if match is None:
+        raise RuntimeError(f'No GitHub auth token found in {npmrcPath}. Run `lpm login` first.')
+    return match.group(1)
 
 
 # Bootstrap the project with required files.
@@ -613,7 +617,7 @@ def syncPackages(packages):
             # Skip sync'ing of other types (packages or libraries) if we're not in a project.
             pass
 
-        elif (packageType == 'program') | (packageType == 'package'):
+        elif packageType in ('program', 'package'):
             destination = getPackageDestination(packageManifest)
             # Find the module(s) in node_modules, and sync it/them.
             for module in os.listdir(os.path.join('node_modules', '@loupeteam')):
@@ -676,7 +680,7 @@ def deployPackages(config, packages):
                     os.path.join('Logical', libraryLocation), os.path.split(package)[1], libraryAttributes
                 )
 
-            elif (packageType == 'program') | (packageType == 'package'):
+            elif packageType in ('program', 'package'):
                 cpuDeployment = getPackageManifestField(packageManifest, ['lpm', 'physical', 'cpu'])
                 taskLocation = getPackageDestination(packageManifest)
                 # First deploy all configured tasks.

--- a/test/test_lpm.py
+++ b/test/test_lpm.py
@@ -52,7 +52,7 @@ class TestLpm:
         if not os.path.exists(LPM_AS_TEMPLATE_PATH):
             os.mkdir(LPM_AS_TEMPLATE_PATH)
 
-        # determine if already set up with library bulder project
+        # determine if already set up with library builder project
         try:
             with open(os.path.join(LPM_AS_TEMPLATE_PATH, 'package.json')) as p:
                 package_dict = json.load(p)


### PR DESCRIPTION
Spun off from [#60](https://github.com/loupeteam/LPM/pull/60). Three pre-existing issues that Copilot flagged in that review but weren't in scope of the Ruff config PR.

## Changes

1. **`getLocalToken()` — file handle + missing-token guard** (`src/lpm_core.py`)
   - Wrap the `~/.npmrc` read in `with open(...)` so the file is closed even if the regex raises.
   - Raise a clear `RuntimeError("Run \`lpm login\` first.")` when no `_authToken=...` line is found, instead of the current `AttributeError: 'NoneType' object has no attribute 'group'`.

2. **Bitwise `|` → membership test** (`src/lpm_core.py`, two sites in `syncPackages` and `deployPackages`)
   - `(packageType == 'program') | (packageType == 'package')` → `packageType in ('program', 'package')`.
   - Works today because both sides are `bool`, but `|` doesn't short-circuit and would silently misbehave if either side ever returns a non-bool.

3. **Typo** (`test/test_lpm.py`) — "bulder" → "builder" in a comment.

## Test plan

- [x] CI lint + test jobs pass.
- [x] Behavior of `getLocalToken()` unchanged on the happy path; clearer error on missing token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)