### PR TITLE
test: add coverage reporting and unit tests for pure helpers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,8 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          pip install -r requirements.txt pytest pytest-cov
-          pip install ./src/ASPython
+          python -m pip install -r requirements.txt pytest pytest-cov
+          python -m pip install ./src/ASPython
 
       # Write ~/.npmrc so that `npm whoami` and `npm install` can reach
       # the GitHub Package Registry.  LPM_TOKEN must be a classic PAT with

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          pip install -r requirements.txt pytest
+          pip install -r requirements.txt pytest pytest-cov
           pip install ./src/ASPython
 
       # Write ~/.npmrc so that `npm whoami` and `npm install` can reach
@@ -64,4 +64,12 @@ jobs:
       - name: Run tests
         # test_build_intel / test_build_arm require Automation Studio to be
         # installed locally and are excluded from CI.
-        run: python -m pytest test/test_lpm.py -v -k "not test_build"
+        run: python -m pytest test/ -v -k "not test_build" --cov=src --cov-report=term-missing --cov-report=xml
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-xml
+          path: coverage.xml
+          if-no-files-found: ignore

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,3 +28,11 @@ quote-style = "single"
 # explicitly so isort classifies it the same way regardless of whether the
 # submodule directory is present in the working tree.
 known-third-party = ["aspython"]
+
+[tool.coverage.run]
+source = ["src"]
+omit = ["src/ASPython/*"]
+
+[tool.coverage.report]
+show_missing = true
+skip_covered = false

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,10 @@
+import os
+import sys
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+_SRC = os.path.join(_REPO_ROOT, 'src')
+_ASPY = os.path.join(_SRC, 'ASPython')
+
+for path in (_SRC, _ASPY):
+    if path not in sys.path:
+        sys.path.insert(0, path)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -5,6 +5,10 @@ _REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 _SRC = os.path.join(_REPO_ROOT, 'src')
 _ASPY = os.path.join(_SRC, 'ASPython')
 
-for path in (_SRC, _ASPY):
+# Prepend in reverse so that `_SRC` ends up at index 0 (highest precedence).
+# There's no naming collision today between modules under `src/` and the
+# vendored `aspython` package, but ordering the search this way matches the
+# intent: project sources first, vendored submodule second.
+for path in (_ASPY, _SRC):
     if path not in sys.path:
         sys.path.insert(0, path)

--- a/test/test_unit_core.py
+++ b/test/test_unit_core.py
@@ -1,0 +1,167 @@
+"""Unit tests for pure helpers in lpm_core.py.
+
+These tests use tmp_path fixtures and small mocks so they run without npm,
+GitHub, or Automation Studio.
+"""
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+import lpm_core
+
+
+class TestGetJsonData:
+    def test_reads_existing_json(self, tmp_path):
+        path = tmp_path / 'data.json'
+        path.write_text(json.dumps({'foo': 'bar', 'n': 1}))
+        assert lpm_core.getJsonData(str(path)) == {'foo': 'bar', 'n': 1}
+
+    def test_creates_missing_file_and_returns_empty(self, tmp_path):
+        path = tmp_path / 'new.json'
+        assert not path.exists()
+        assert lpm_core.getJsonData(str(path)) == {}
+        # The file should now exist (created via 'x' mode).
+        assert path.exists()
+
+    def test_empty_file_returns_empty_dict(self, tmp_path):
+        path = tmp_path / 'empty.json'
+        path.write_text('')
+        assert lpm_core.getJsonData(str(path)) == {}
+
+    def test_invalid_json_returns_empty_dict(self, tmp_path):
+        path = tmp_path / 'bad.json'
+        path.write_text('{not valid json')
+        assert lpm_core.getJsonData(str(path)) == {}
+
+
+class TestSaveJsonData:
+    def test_writes_indented_json(self, tmp_path):
+        path = tmp_path / 'out.json'
+        lpm_core.saveJsonData({'a': 1, 'b': [2, 3]}, str(path))
+        assert json.loads(path.read_text()) == {'a': 1, 'b': [2, 3]}
+        # Indented output should contain newlines.
+        assert '\n' in path.read_text()
+
+    def test_overwrites_existing_file(self, tmp_path):
+        path = tmp_path / 'out.json'
+        path.write_text('{"old": true}')
+        lpm_core.saveJsonData({'new': True}, str(path))
+        assert json.loads(path.read_text()) == {'new': True}
+
+    def test_roundtrip_with_get(self, tmp_path):
+        path = tmp_path / 'rt.json'
+        original = {'x': {'y': [1, 2, {'z': 'q'}]}}
+        lpm_core.saveJsonData(original, str(path))
+        assert lpm_core.getJsonData(str(path)) == original
+
+
+class TestGetPackageManifestField:
+    @pytest.fixture
+    def manifest(self, tmp_path):
+        path = tmp_path / 'package.json'
+        path.write_text(
+            json.dumps(
+                {
+                    'name': '@loupeteam/foo',
+                    'version': '1.2.3',
+                    'lpm': {'type': 'library'},
+                    'lpmConfig': {'deploymentConfigs': ['Intel', 'Arm'], 'gitClient': 'GitExtensions'},
+                    'dependencies': {'@loupeteam/bar': '^0.1.0'},
+                }
+            )
+        )
+        return str(path)
+
+    def test_top_level_field(self, manifest):
+        assert lpm_core.getPackageManifestField(manifest, ['name']) == '@loupeteam/foo'
+
+    def test_nested_field(self, manifest):
+        assert lpm_core.getPackageManifestField(manifest, ['lpm', 'type']) == 'library'
+
+    def test_returns_dict(self, manifest):
+        assert lpm_core.getPackageManifestField(manifest, ['dependencies']) == {'@loupeteam/bar': '^0.1.0'}
+
+    def test_returns_list(self, manifest):
+        assert lpm_core.getPackageManifestField(manifest, ['lpmConfig', 'deploymentConfigs']) == ['Intel', 'Arm']
+
+    def test_missing_top_level_returns_none(self, manifest):
+        assert lpm_core.getPackageManifestField(manifest, ['nope']) is None
+
+    def test_missing_nested_returns_none(self, manifest):
+        assert lpm_core.getPackageManifestField(manifest, ['lpm', 'missing']) is None
+
+    def test_descend_into_non_dict_returns_none(self, manifest):
+        # 'name' resolves to a string; further path elements should fail safely.
+        assert lpm_core.getPackageManifestField(manifest, ['name', 'extra']) is None
+
+
+class TestSetPackageManifestField:
+    @pytest.fixture
+    def manifest(self, tmp_path):
+        path = tmp_path / 'package.json'
+        path.write_text(json.dumps({'name': '@loupeteam/foo', 'version': '1.0.0'}))
+        return str(path)
+
+    def test_creates_lpmconfig_when_missing(self, manifest):
+        lpm_core.setPackageManifestField(manifest, 'gitClient', 'GitExtensions')
+        with open(manifest) as f:
+            data = json.load(f)
+        assert data['lpmConfig'] == {'gitClient': 'GitExtensions'}
+        # Untouched fields preserved.
+        assert data['name'] == '@loupeteam/foo'
+        assert data['version'] == '1.0.0'
+
+    def test_updates_existing_lpmconfig(self, tmp_path):
+        path = tmp_path / 'package.json'
+        path.write_text(json.dumps({'name': 'x', 'lpmConfig': {'deploymentConfigs': ['Intel'], 'gitClient': 'old'}}))
+        lpm_core.setPackageManifestField(str(path), 'gitClient', 'GitExtensions')
+        with open(path) as f:
+            data = json.load(f)
+        assert data['lpmConfig']['gitClient'] == 'GitExtensions'
+        # Other lpmConfig keys should remain.
+        assert data['lpmConfig']['deploymentConfigs'] == ['Intel']
+
+    def test_writes_list_field(self, manifest):
+        lpm_core.setPackageManifestField(manifest, 'deploymentConfigs', ['Intel', 'Arm'])
+        with open(manifest) as f:
+            data = json.load(f)
+        assert data['lpmConfig']['deploymentConfigs'] == ['Intel', 'Arm']
+
+
+class TestGetPackageType:
+    """Covers the manifest-based path. The ASTools-based fallback is exercised
+    by the integration tests."""
+
+    def test_reads_lpm_type_from_manifest(self, tmp_path):
+        (tmp_path / 'package.json').write_text(json.dumps({'lpm': {'type': 'library'}}))
+        assert lpm_core.getPackageType(str(tmp_path)) == 'library'
+
+    def test_program_type(self, tmp_path):
+        (tmp_path / 'package.json').write_text(json.dumps({'lpm': {'type': 'program'}}))
+        assert lpm_core.getPackageType(str(tmp_path)) == 'program'
+
+    def test_project_type(self, tmp_path):
+        (tmp_path / 'package.json').write_text(json.dumps({'lpm': {'type': 'project'}}))
+        assert lpm_core.getPackageType(str(tmp_path)) == 'project'
+
+
+class TestGetRepoName:
+    def test_extracts_repo_name_from_html_url(self):
+        fake_data = {'repository': {'html_url': 'https://github.com/loupeteam/atn'}}
+        with patch.object(lpm_core, 'getLoupePackageData', return_value=(None, fake_data)):
+            assert lpm_core.getRepoName('@loupeteam/atn') == 'atn'
+
+    def test_returns_none_when_html_url_missing(self, capsys):
+        fake_data = {'repository': {}}
+        with patch.object(lpm_core, 'getLoupePackageData', return_value=(None, fake_data)):
+            assert lpm_core.getRepoName('@loupeteam/atn') is None
+
+    def test_returns_none_when_repository_missing(self, capsys):
+        with patch.object(lpm_core, 'getLoupePackageData', return_value=(None, {})):
+            assert lpm_core.getRepoName('@loupeteam/atn') is None
+
+    def test_returns_none_on_error(self, capsys):
+        with patch.object(lpm_core, 'getLoupePackageData', return_value=('boom', None)):
+            assert lpm_core.getRepoName('@loupeteam/atn') is None

--- a/test/test_unit_core.py
+++ b/test/test_unit_core.py
@@ -153,15 +153,15 @@ class TestGetRepoName:
         with patch.object(lpm_core, 'getLoupePackageData', return_value=(None, fake_data)):
             assert lpm_core.getRepoName('@loupeteam/atn') == 'atn'
 
-    def test_returns_none_when_html_url_missing(self, capsys):
+    def test_returns_none_when_html_url_missing(self):
         fake_data = {'repository': {}}
         with patch.object(lpm_core, 'getLoupePackageData', return_value=(None, fake_data)):
             assert lpm_core.getRepoName('@loupeteam/atn') is None
 
-    def test_returns_none_when_repository_missing(self, capsys):
+    def test_returns_none_when_repository_missing(self):
         with patch.object(lpm_core, 'getLoupePackageData', return_value=(None, {})):
             assert lpm_core.getRepoName('@loupeteam/atn') is None
 
-    def test_returns_none_on_error(self, capsys):
+    def test_returns_none_on_error(self):
         with patch.object(lpm_core, 'getLoupePackageData', return_value=('boom', None)):
             assert lpm_core.getRepoName('@loupeteam/atn') is None

--- a/test/test_unit_lpm.py
+++ b/test/test_unit_lpm.py
@@ -1,7 +1,9 @@
 """Unit tests for pure helpers in LPM.py.
 
-These tests do not touch the filesystem, network, npm, or Automation Studio —
-they exercise argv munging and package-name normalization in isolation.
+These tests don't hit the network, npm, or Automation Studio — they exercise
+argv munging and package-name normalization in isolation. (Importing `LPM`
+does read `src/version.json` at module load time, but that's the only
+filesystem touch and it's incidental to the tests themselves.)
 """
 
 import pytest

--- a/test/test_unit_lpm.py
+++ b/test/test_unit_lpm.py
@@ -1,0 +1,131 @@
+"""Unit tests for pure helpers in LPM.py.
+
+These tests do not touch the filesystem, network, npm, or Automation Studio —
+they exercise argv munging and package-name normalization in isolation.
+"""
+
+import pytest
+
+import LPM
+
+
+class TestNormalizePackages:
+    def test_empty_input(self):
+        packages, versions = LPM._normalize_packages([])
+        assert packages == []
+        assert versions == []
+
+    def test_none_input(self):
+        packages, versions = LPM._normalize_packages(None)
+        assert packages == []
+        assert versions == []
+
+    def test_single_bare_name(self):
+        packages, versions = LPM._normalize_packages(['atn'])
+        assert packages == ['@loupeteam/atn']
+        assert versions == ['']
+
+    def test_uppercase_is_lowercased(self):
+        packages, versions = LPM._normalize_packages(['ATN'])
+        assert packages == ['@loupeteam/atn']
+        assert versions == ['']
+
+    def test_with_version_suffix(self):
+        packages, versions = LPM._normalize_packages(['atn@1.2.3'])
+        assert packages == ['@loupeteam/atn']
+        assert versions == ['1.2.3']
+
+    def test_multiple_packages_mixed(self):
+        packages, versions = LPM._normalize_packages(['atn', 'vartools@0.11.3', 'StringExt'])
+        assert packages == ['@loupeteam/atn', '@loupeteam/vartools', '@loupeteam/stringext']
+        assert versions == ['', '0.11.3', '']
+
+    def test_version_with_prerelease_tag(self):
+        packages, versions = LPM._normalize_packages(['atn@1.2.3-beta.1'])
+        assert packages == ['@loupeteam/atn']
+        assert versions == ['1.2.3-beta.1']
+
+    def test_returned_lists_are_aligned(self):
+        packages, versions = LPM._normalize_packages(['a', 'b@1', 'c@2'])
+        assert len(packages) == len(versions) == 3
+
+
+class TestHoistGlobalFlags:
+    def test_empty(self):
+        assert LPM._hoist_global_flags([]) == []
+
+    def test_already_in_front(self):
+        assert LPM._hoist_global_flags(['--silent', 'install', 'pkg']) == ['--silent', 'install', 'pkg']
+
+    def test_silent_short_after_subcommand(self):
+        assert LPM._hoist_global_flags(['install', '-s']) == ['-s', 'install']
+
+    def test_silent_long_after_subcommand(self):
+        assert LPM._hoist_global_flags(['install', '--silent']) == ['--silent', 'install']
+
+    def test_silent_after_packages(self):
+        assert LPM._hoist_global_flags(['install', 'pkg', '--silent']) == ['--silent', 'install', 'pkg']
+
+    def test_nocolor_short(self):
+        assert LPM._hoist_global_flags(['install', 'pkg', '-nc']) == ['-nc', 'install', 'pkg']
+
+    def test_nocolor_long(self):
+        assert LPM._hoist_global_flags(['install', 'pkg', '--nocolor']) == ['--nocolor', 'install', 'pkg']
+
+    def test_two_global_flags_after(self):
+        result = LPM._hoist_global_flags(['install', 'pkg', '--silent', '--nocolor'])
+        # Both flags should land before the subcommand; their relative order is
+        # implementation-defined but both must precede 'install'.
+        assert result.index('--silent') < result.index('install')
+        assert result.index('--nocolor') < result.index('install')
+        assert 'pkg' in result and result.index('pkg') > result.index('install')
+
+    def test_unknown_flag_passes_through(self):
+        # Subcommand-specific flags like --source must not be hoisted.
+        assert LPM._hoist_global_flags(['install', 'pkg', '--source']) == ['install', 'pkg', '--source']
+
+    def test_no_subcommand(self):
+        # If no positional ever appears, flags are returned unchanged.
+        assert LPM._hoist_global_flags(['--silent']) == ['--silent']
+
+
+class TestIsKnownCommand:
+    @pytest.fixture
+    def parser_and_sub(self):
+        return LPM._build_parser('LPM')
+
+    @pytest.mark.parametrize(
+        'cmd',
+        ['install', 'uninstall', 'login', 'logout', 'status', 'init', 'view', 'info', 'list'],
+    )
+    def test_known_subcommands(self, parser_and_sub, cmd):
+        parser, sub = parser_and_sub
+        assert LPM._is_known_command(parser, sub, [cmd]) is True
+
+    def test_unknown_command_returns_false(self, parser_and_sub):
+        parser, sub = parser_and_sub
+        assert LPM._is_known_command(parser, sub, ['ci']) is False
+
+    def test_help_short(self, parser_and_sub):
+        parser, sub = parser_and_sub
+        assert LPM._is_known_command(parser, sub, ['-h']) is True
+
+    def test_help_long(self, parser_and_sub):
+        parser, sub = parser_and_sub
+        assert LPM._is_known_command(parser, sub, ['--help']) is True
+
+    def test_version(self, parser_and_sub):
+        parser, sub = parser_and_sub
+        assert LPM._is_known_command(parser, sub, ['-v']) is True
+
+    def test_global_flag_then_known_command(self, parser_and_sub):
+        parser, sub = parser_and_sub
+        assert LPM._is_known_command(parser, sub, ['--silent', 'install']) is True
+
+    def test_global_flag_then_unknown_command(self, parser_and_sub):
+        parser, sub = parser_and_sub
+        assert LPM._is_known_command(parser, sub, ['--silent', 'ci']) is False
+
+    def test_empty_argv(self, parser_and_sub):
+        parser, sub = parser_and_sub
+        assert LPM._is_known_command(parser, sub, []) is False


### PR DESCRIPTION
## Summary
- Wire `pytest-cov` into the Windows CI test job. Each PR now prints a `term-missing` coverage summary in the log and uploads `coverage.xml` as a build artifact. No `--cov-fail-under` yet so we can see what the real baseline is before locking it in.
- Add `[tool.coverage]` config to `pyproject.toml` scoping coverage to `src/` and excluding the vendored `src/ASPython/` submodule.
- Add 58 unit tests for pure helpers that don't need npm, GitHub auth, or Automation Studio:
  - `test/test_unit_lpm.py` — `_normalize_packages` (scope prefix, `@version` split, casing, prerelease tags), `_hoist_global_flags` edge cases (unknown flag pass-through, two-flag interleaving), `_is_known_command` parametrized over known/unknown commands plus `-h`/`-v`/global-flag prefixes.
  - `test/test_unit_core.py` — `getJsonData` / `saveJsonData` (missing file, empty, invalid JSON, roundtrip), `getPackageManifestField` (top-level / nested / list / dict / missing / non-dict descent), `setPackageManifestField` (creates `lpmConfig` when missing, preserves siblings), manifest-based path of `getPackageType`, `getRepoName` with `getLoupePackageData` mocked.
- Add `test/conftest.py` to centralize `sys.path` setup for `src/` and `src/ASPython/`.

## Baseline
Unit tests alone (without integration): 23% (`src/LPM.py` 34%, `src/lpm_core.py` 16%). CI will be higher because the integration tests there exercise `install` / `sync` / `deploy`. The point of this PR is to make that number visible on every PR going forward.

## Test plan
- [x] CI lint job passes (ruff check + format check).
- [x] CI test job passes and prints a coverage table.
- [x] `coverage-xml` artifact is attached to the run.
- [x] No regression in the existing integration tests in `test/test_lpm.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)