### PR TITLE
fix: report accurate LASTUPDATED in lpm viewall

### DIFF
--- a/src/lpm_core.py
+++ b/src/lpm_core.py
@@ -19,6 +19,7 @@ import os.path
 import re
 import shutil
 import subprocess
+from concurrent.futures import ThreadPoolExecutor
 
 import aspython as ASTools
 import requests
@@ -867,6 +868,14 @@ def printLoupePackageList():
             except:
                 package_descriptions.append(' ')
 
+        # The `updated_at` returned by /orgs/{org}/packages doesn't reliably reflect
+        # the most recent version publish (it often reports the package's initial
+        # publish date), so fetch each package's latest version date directly.
+        with ThreadPoolExecutor(max_workers=10) as executor:
+            last_updated_dates = list(
+                executor.map(lambda p: getLoupePackageLatestVersionDate(p['name']), packages_sorted)
+            )
+
         # Determine column widths.
         name_col_width = max(len(package['name']) for package in packages_sorted) + 2
         version_col_width = 12
@@ -888,10 +897,16 @@ def printLoupePackageList():
         )
 
         for idx, package in enumerate(packages_sorted):
+            date_error, latest_date = last_updated_dates[idx]
+            if not date_error and latest_date:
+                last_updated = latest_date[:10]
+            else:
+                fallback = package.get('updated_at') or ''
+                last_updated = fallback[:10] if fallback else 'unknown'
             print(
                 package['name'].ljust(name_col_width)
                 + str(package['version_count']).ljust(version_col_width)
-                + package['updated_at'][:10].ljust(lastmod_col_width)
+                + last_updated.ljust(lastmod_col_width)
                 + package_descriptions[idx].ljust(description_col_width)
             )
     else:
@@ -952,6 +967,38 @@ def getLoupePackageData(packageName: str):
         return (error, [])  # Early return
     packageData = json.loads(r.content)
     return (None, packageData)
+
+
+# Fetches the most recently published version's timestamp for a package.
+# Returns (error, isoDateString) tuple; error is None on success.
+def getLoupePackageLatestVersionDate(packageName: str):
+    try:
+        token = getLocalToken()
+        headers = {
+            'Authorization': f'Bearer {token}',
+            'Accept': 'application/vnd.github+json',
+            'X-GitHub-Api-Version': '2022-11-28',
+        }
+        organization = 'loupeteam'
+        packageNameStripped = os.path.split(packageName)[1]
+        r = requests.get(
+            f'https://api.github.com/orgs/{organization}/packages/npm/{packageNameStripped}/versions',
+            headers=headers,
+            params={'per_page': '1'},
+            timeout=5,
+        )
+        if r.status_code != 200:
+            return (f'Status code not OK. Code: {r.status_code}', None)
+        versions = json.loads(r.content)
+        if not isinstance(versions, list) or not versions:
+            return ('No versions found', None)
+        # GitHub returns versions sorted by created_at descending.
+        latest = versions[0]
+        if not isinstance(latest, dict):
+            return ('Unexpected version payload', None)
+        return (None, latest.get('updated_at') or latest.get('created_at'))
+    except Exception as e:
+        return (f'Failed to fetch latest version date: {e}', None)
 
 
 # Run a generic NPM command on the specified packages.


### PR DESCRIPTION
## Summary
- `lpm viewall` was showing each package's *initial* publish date in the `LASTUPDATED` column instead of the most recent publish date. The value came from GitHub's `/orgs/{org}/packages` endpoint, whose `updated_at` field doesn't reliably reflect the latest version publish for npm packages on GitHub Packages.
- Fix fetches each package's latest version timestamp from `/orgs/{org}/packages/npm/{name}/versions?per_page=1` and uses that. Calls run in parallel via a `ThreadPoolExecutor` (10 workers) to keep the command responsive.
- If the per-package fetch fails (network error, non-200 status, missing/malformed JSON, unexpected payload, etc.), the table falls back to the original `updated_at` value, or to `unknown` if that's also missing — a single hiccup won't break the whole listing.

## Test plan
- [x] Run `lpm viewall` against a real GitHub token and confirm `LASTUPDATED` matches the latest version publish date shown on each package's GitHub Packages page.
- [x] Confirm the command still completes promptly across the full org package list.
- [x] Sanity check: `python -m ruff check src/lpm_core.py` and `python -m ruff format --check src/lpm_core.py` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)