### PR TITLE
fix: install lpm into a bundled venv so aspython resolves

### DIFF
--- a/bin/lpm.js
+++ b/bin/lpm.js
@@ -2,12 +2,26 @@
 'use strict';
 
 const { spawnSync } = require('child_process');
+const fs = require('fs');
 const path = require('path');
 
-const lpmScript = path.join(__dirname, '..', 'src', 'LPM.py');
-const python = process.platform === 'win32' ? 'python' : 'python3';
+const PACKAGE_ROOT = path.resolve(__dirname, '..');
+const VENV_PYTHON = process.platform === 'win32'
+  ? path.join(PACKAGE_ROOT, '.venv', 'Scripts', 'python.exe')
+  : path.join(PACKAGE_ROOT, '.venv', 'bin', 'python');
+const LPM_SCRIPT = path.join(PACKAGE_ROOT, 'src', 'LPM.py');
 
-const result = spawnSync(python, [lpmScript, ...process.argv.slice(2)], {
+if (!fs.existsSync(VENV_PYTHON)) {
+  console.error(
+    `\nLPM error: bundled Python venv not found at ${VENV_PYTHON}.\n` +
+    'The npm postinstall step did not complete successfully. ' +
+    'Re-run `npm install -g @loupeteam/lpm` (or `npm install` in your project) ' +
+    'and check the output for the underlying error (commonly: Python 3.8+ is not on PATH).\n'
+  );
+  process.exit(1);
+}
+
+const result = spawnSync(VENV_PYTHON, [LPM_SCRIPT, ...process.argv.slice(2)], {
   stdio: 'inherit',
   shell: false,
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loupeteam/lpm",
-  "version": "1.2.0",
+  "version": "1.2.1-beta.0",
   "description": "LPM - Loupe Package Manager. A lightweight wrapper around NPM that processes Loupe packages.",
   "homepage": "https://loupeteam.github.io/LoupeDocs/tools/lpm.html",
   "repository": {

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,30 +1,70 @@
 'use strict';
 
 const { spawnSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
 
-const candidates = ['python', 'python3'];
-let py = null;
+const PACKAGE_ROOT = path.resolve(__dirname, '..');
+const VENV_DIR = path.join(PACKAGE_ROOT, '.venv');
+const REQUIREMENTS = path.join(PACKAGE_ROOT, 'requirements.txt');
+const ASPYTHON_DIR = path.join(PACKAGE_ROOT, 'src', 'ASPython');
+const MIN_PY = [3, 8];
 
-for (const cmd of candidates) {
-  const check = spawnSync(cmd, ['-m', 'pip', '--version'], { stdio: 'ignore' });
-  if (check.status === 0) {
-    py = cmd;
-    break;
+function pickPythonLauncher() {
+  // [command, [...args], pretty]
+  const candidates = process.platform === 'win32'
+    ? [['py', ['-3'], 'py -3'], ['python', [], 'python'], ['python3', [], 'python3']]
+    : [['python3', [], 'python3'], ['python', [], 'python']];
+
+  const probe = '__import__("sys").stdout.write("{}.{}".format(*__import__("sys").version_info[:2]))';
+  for (const [cmd, args, pretty] of candidates) {
+    const r = spawnSync(cmd, [...args, '-c', probe], { encoding: 'utf8' });
+    if (r.status !== 0 || !r.stdout) continue;
+    const [maj, min] = r.stdout.trim().split('.').map(Number);
+    if (maj > MIN_PY[0] || (maj === MIN_PY[0] && min >= MIN_PY[1])) {
+      return { cmd, args, pretty, version: `${maj}.${min}` };
+    }
+  }
+  return null;
+}
+
+function venvPython() {
+  return process.platform === 'win32'
+    ? path.join(VENV_DIR, 'Scripts', 'python.exe')
+    : path.join(VENV_DIR, 'bin', 'python');
+}
+
+function run(cmd, args, label) {
+  const r = spawnSync(cmd, args, { stdio: 'inherit' });
+  if (r.status !== 0) {
+    console.error(`\nLPM postinstall: ${label} failed (exit ${r.status}).`);
+    process.exit(r.status || 1);
   }
 }
 
-if (!py) {
+const launcher = pickPythonLauncher();
+if (!launcher) {
   console.error(
-    '\nLPM postinstall error: Python 3 and pip are required but were not found on PATH.\n' +
-    'Please install Python 3 with pip (https://www.python.org/downloads/) and re-run npm install.\n'
+    `\nLPM postinstall error: Python ${MIN_PY[0]}.${MIN_PY[1]}+ is required but was not found on PATH.\n` +
+    'Install Python 3 (https://www.python.org/downloads/) and re-run `npm install`.\n'
   );
   process.exit(1);
 }
 
-const result = spawnSync(
-  py,
-  ['-m', 'pip', 'install', '--user', '-r', 'requirements.txt'],
-  { stdio: 'inherit' }
-);
+if (!fs.existsSync(path.join(ASPYTHON_DIR, 'pyproject.toml'))) {
+  console.error(
+    `\nLPM postinstall error: bundled ASPython package not found at ${ASPYTHON_DIR}.\n` +
+    'If you are installing from a git clone, run `git submodule update --init` and try again.\n'
+  );
+  process.exit(1);
+}
 
-process.exit(result.status || 0);
+console.log(`LPM postinstall: using ${launcher.pretty} (Python ${launcher.version}); creating venv at ${VENV_DIR}`);
+run(launcher.cmd, [...launcher.args, '-m', 'venv', VENV_DIR], 'venv creation');
+
+const py = venvPython();
+run(py, ['-m', 'pip', 'install', '--upgrade', 'pip'], 'pip upgrade');
+run(py, ['-m', 'pip', 'install', '-r', REQUIREMENTS], 'requirements install');
+run(py, ['-m', 'pip', 'install', ASPYTHON_DIR], 'aspython install');
+
+console.log('LPM postinstall: complete.');


### PR DESCRIPTION
## Summary
Fixes `ModuleNotFoundError: No module named 'aspython'` on a fresh `npm install -g @loupeteam/lpm`.

Two stacked problems caused it:
- `aspython` (vendored at `src/ASPython/`) was never installed by the postinstall — it's not in `requirements.txt` and the wrapper never put `src/ASPython/` on `sys.path`.
- `pip install --user` ran against whatever `python` came first on PATH, which can drift from the interpreter `bin/lpm.js` later picks.

This change:
- `scripts/postinstall.js` picks a Python 3.8+ (prefers `py -3` on Windows, `python3` elsewhere), creates `.venv` next to `package.json`, installs `requirements.txt`, then `pip install ./src/ASPython` so it lands as a real package (pulling its own deps like `lxml` via its `pyproject.toml`).
- `bin/lpm.js` invokes the venv's `python` by absolute path — no PATH lookup, no interpreter drift. If the venv is missing it prints a clear pointer back to re-running `npm install` instead of the cryptic `ModuleNotFoundError`.
- `.venv/` is already gitignored and is not in the `files` allowlist, so it's created on the consumer machine and never shipped in the npm tarball.

## Test plan
- [x] Local: `rm -rf .venv && node scripts/postinstall.js` builds a venv with requirements + aspython (incl. lxml) on Windows.
- [x] Local: `node bin/lpm.js --version` prints `LPM: 1.2.0` (proves `import aspython` resolves).
- [x] Reviewer: try `npm install -g .` from a fresh clone (with submodule initialized) on macOS/Linux.
- [ ] Reviewer: confirm clear error when Python is missing or < 3.8.
- [ ] Reviewer: confirm clear error when running `lpm` against an install where postinstall did not complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)