### PR TITLE
fix: skip packages with missing manifests instead of crashing install

### DIFF
--- a/src/lpm_core.py
+++ b/src/lpm_core.py
@@ -526,6 +526,11 @@ def getAllDependencies(packages):
     for package in packages:
         # Introspect the package.json for this file. Find its 'lpm/type' field.
         packageManifest = os.path.join('node_modules', package, 'package.json')
+        # Transitive npm deps may not live at the top-level node_modules path
+        # (npm 7+ hoists/nests by its own rules). Treat a missing manifest as
+        # "not an lpm-managed package, skip" — npm has already handled it.
+        if not os.path.exists(packageManifest):
+            continue
         packageType = getPackageManifestField(packageManifest, ['lpm', 'type'])
         # When dealing with an HMI project, don't parse through its dependencies recursively! That gets deep real fast.
         if packageType == 'hmi-project':
@@ -599,6 +604,10 @@ def syncPackages(packages):
     for package in packages:
         # Introspect the package.json for this file. Find its 'lpm' section.
         packageManifest = os.path.join('node_modules', package, 'package.json')
+        # Defensive: a caller may hand us a package whose manifest npm hoisted
+        # elsewhere. Without a manifest there's nothing lpm can sync, so skip.
+        if not os.path.exists(packageManifest):
+            continue
         packageType = getPackageManifestField(packageManifest, ['lpm', 'type'])
         # Do something different based on package type.
         if packageType == 'project':


### PR DESCRIPTION
## Summary
`lpm install <package...>` was crashing with `FileNotFoundError: [Errno 2] No such file or directory: 'node_modules\b4a\package.json'` whenever a transitive npm dependency wasn't placed at the top-level `node_modules/<name>/` (which npm 7+ does routinely via hoisting/nesting decisions outside our control).

Both `getAllDependencies` and `syncPackages` opened `node_modules/<package>/package.json` unconditionally to read `lpm.type`. Existing `os.path.exists` guards only protected the *dependencies* read below, not the type read above it. So any transitive dep whose manifest wasn't at the expected path took the whole install down.

This change treats a missing manifest as \"not an lpm-managed package, skip\" — npm has already placed the package itself, lpm just has nothing to sync for it. The dependency walk stays agnostic to the `@loupeteam` scope, so packages from other registries keep working.

Reproduced by @Scott installing a large set of Loupe packages whose dep graph pulled in `b4a` ([traceback in PR description discussion](#)). The crash happened three levels deep into recursion in `getAllDependencies` — exactly the kind of transitive non-lpm package the existing existence-check was *intended* to handle, just on the wrong line.

## Test plan
- [ ] Run `lpm install` against a project whose dep tree includes a transitive npm package not present at top-level `node_modules/` (e.g. the package set in the reported failure). Confirm install completes without `FileNotFoundError`.
- [ ] Sanity-check existing happy-path installs still work and still sync `@loupeteam/*` packages into `Logical/Libraries/Loupe/`.
- [ ] No new behavior change for HMI-project handling or source-library fallback (only adds an early skip for the missing-manifest case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)