### PR TITLE
fix: stop walking transitive deps of non-lpm packages and memoize visits

### DIFF
--- a/src/lpm_core.py
+++ b/src/lpm_core.py
@@ -521,9 +521,18 @@ def getRepoName(package):
 
 # Retrieve a deep list of all dependencies of the specified packages.
 # This is recursive logic that hurts my brain, but seems to work.
-def getAllDependencies(packages):
+def getAllDependencies(packages, _seen=None):
+    # _seen is an internal recursion-scoped set used to memoize visited
+    # packages so cycles and diamond deps don't re-walk the same subtree.
+    # Callers should always omit it.
+    if _seen is None:
+        _seen = set()
     dependencies = []
     for package in packages:
+        lowerPackage = package.lower()
+        if lowerPackage in _seen:
+            continue
+        _seen.add(lowerPackage)
         # Introspect the package.json for this file. Find its 'lpm/type' field.
         packageManifest = os.path.join('node_modules', package, 'package.json')
         # Transitive npm deps may not live at the top-level node_modules path
@@ -536,27 +545,20 @@ def getAllDependencies(packages):
         if packageType == 'hmi-project':
             return packages
         dependencies.append(package)
-        # If package.json exists, get dependencies from there.
-        if os.path.exists(os.path.join('node_modules', package, 'package.json')):
-            dependencyData = getPackageManifestField(
-                os.path.join('node_modules', package, 'package.json'), ['dependencies']
-            )
-            if dependencyData is None:
-                dependencyData = []
-        # If there is no package.json for this package, assume it's a source library, and that it's already sync'd
-        # to the Logical View under Libraries / Loupe.
-        else:
-            # Strip it of its @loupeteam prefix.
-            splitPackage = os.path.split(package)[1]
-            dependencyData = getLibrarySourceDependencies(
-                os.path.join('.', 'Logical', 'Libraries', 'Loupe', splitPackage)
-            )
-            print('Source dependencies: ')
-            print(dependencyData)
+        # Plain npm packages (no `lpm` config) are leaves from lpm's
+        # perspective: npm has already placed them and there's nothing for
+        # lpm to sync. Walking their transitive npm deps (e.g. node-opcua's
+        # hundreds of subpackages) is wasteful at best and can hang the
+        # install at worst.
+        if packageType is None:
+            continue
+        dependencyData = getPackageManifestField(packageManifest, ['dependencies'])
+        if dependencyData is None:
+            dependencyData = []
         localDependencies = []
         for item in dependencyData:
             localDependencies.append(item)
-        nestedDependencies = getAllDependencies(localDependencies)
+        nestedDependencies = getAllDependencies(localDependencies, _seen)
         for item in nestedDependencies:
             dependencies.append(item)
     # Before returning the list, sanitize it by removing duplicates.

--- a/test/test_unit_core.py
+++ b/test/test_unit_core.py
@@ -165,3 +165,95 @@ class TestGetRepoName:
     def test_returns_none_on_error(self):
         with patch.object(lpm_core, 'getLoupePackageData', return_value=('boom', None)):
             assert lpm_core.getRepoName('@loupeteam/atn') is None
+
+
+class TestGetAllDependencies:
+    """getAllDependencies walks a project's node_modules to build a flat list
+    of lpm-managed packages to sync. These tests build a fake node_modules
+    layout under tmp_path and chdir into it so we exercise the real
+    file-reading code paths.
+    """
+
+    @staticmethod
+    def _writeManifest(root, packageName, manifest):
+        # packageName may include a scope ('@scope/name') or be bare ('name').
+        manifestPath = root / 'node_modules' / packageName / 'package.json'
+        manifestPath.parent.mkdir(parents=True, exist_ok=True)
+        manifestPath.write_text(json.dumps(manifest))
+
+    def test_single_lpm_package_with_no_deps_returns_itself(self, tmp_path, monkeypatch):
+        self._writeManifest(tmp_path, '@a/x', {'lpm': {'type': 'library'}})
+        monkeypatch.chdir(tmp_path)
+        assert lpm_core.getAllDependencies(['@a/x']) == ['@a/x']
+
+    def test_walks_lpm_managed_transitive_deps(self, tmp_path, monkeypatch):
+        # @a/x is lpm-managed and depends on @a/y, which is also lpm-managed.
+        self._writeManifest(tmp_path, '@a/x', {'lpm': {'type': 'library'}, 'dependencies': {'@a/y': '*'}})
+        self._writeManifest(tmp_path, '@a/y', {'lpm': {'type': 'library'}})
+        monkeypatch.chdir(tmp_path)
+        result = lpm_core.getAllDependencies(['@a/x'])
+        assert result == ['@a/x', '@a/y']
+
+    def test_non_lpm_package_is_a_leaf(self, tmp_path, monkeypatch):
+        # Regression for the opcua-proxy hang: a package with no `lpm` field
+        # must NOT have its (potentially huge) npm dep tree walked. We create
+        # real manifests for the npm deps so an unfixed walker would happily
+        # recurse into them; the assertion is that only the requested package
+        # comes back.
+        self._writeManifest(
+            tmp_path,
+            '@a/x',
+            {'dependencies': {'express': '*', 'node-opcua': '*'}},
+        )
+        self._writeManifest(tmp_path, 'express', {'dependencies': {'body-parser': '*'}})
+        self._writeManifest(tmp_path, 'body-parser', {})
+        self._writeManifest(tmp_path, 'node-opcua', {})
+        monkeypatch.chdir(tmp_path)
+        result = lpm_core.getAllDependencies(['@a/x'])
+        # Only @a/x — none of the plain npm packages, transitive or otherwise,
+        # should appear in the lpm sync list.
+        assert result == ['@a/x']
+
+    def test_skips_packages_with_missing_manifest(self, tmp_path, monkeypatch):
+        # Regression for #83: a transitive dep that npm hoisted to a nested
+        # location is not at node_modules/<name>/package.json. Must skip it
+        # rather than crashing.
+        self._writeManifest(tmp_path, '@a/x', {'lpm': {'type': 'library'}, 'dependencies': {'@a/missing': '*'}})
+        monkeypatch.chdir(tmp_path)
+        # Should return @a/x and silently skip @a/missing.
+        assert lpm_core.getAllDependencies(['@a/x']) == ['@a/x']
+
+    def test_handles_dependency_cycles(self, tmp_path, monkeypatch):
+        # A -> B -> A. Memoization must terminate the walk.
+        self._writeManifest(tmp_path, '@a/x', {'lpm': {'type': 'library'}, 'dependencies': {'@a/y': '*'}})
+        self._writeManifest(tmp_path, '@a/y', {'lpm': {'type': 'library'}, 'dependencies': {'@a/x': '*'}})
+        monkeypatch.chdir(tmp_path)
+        result = lpm_core.getAllDependencies(['@a/x'])
+        assert sorted(result) == ['@a/x', '@a/y']
+
+    def test_dedupes_diamond_dependencies(self, tmp_path, monkeypatch):
+        # A -> B, A -> C, B -> D, C -> D. D appears once in result.
+        self._writeManifest(
+            tmp_path, '@a/a', {'lpm': {'type': 'library'}, 'dependencies': {'@a/b': '*', '@a/c': '*'}}
+        )
+        self._writeManifest(tmp_path, '@a/b', {'lpm': {'type': 'library'}, 'dependencies': {'@a/d': '*'}})
+        self._writeManifest(tmp_path, '@a/c', {'lpm': {'type': 'library'}, 'dependencies': {'@a/d': '*'}})
+        self._writeManifest(tmp_path, '@a/d', {'lpm': {'type': 'library'}})
+        monkeypatch.chdir(tmp_path)
+        result = lpm_core.getAllDependencies(['@a/a'])
+        assert sorted(result) == ['@a/a', '@a/b', '@a/c', '@a/d']
+        assert result.count('@a/d') == 1
+
+    def test_hmi_project_short_circuits_recursion(self, tmp_path, monkeypatch):
+        # hmi-project deps are deliberately not walked recursively (they're
+        # entire applications, not libraries). Existing behavior preserved.
+        self._writeManifest(
+            tmp_path,
+            '@a/hmi',
+            {'lpm': {'type': 'hmi-project'}, 'dependencies': {'@a/should-not-walk': '*'}},
+        )
+        self._writeManifest(tmp_path, '@a/should-not-walk', {'lpm': {'type': 'library'}})
+        monkeypatch.chdir(tmp_path)
+        result = lpm_core.getAllDependencies(['@a/hmi'])
+        # Returns the original input untouched, not the walked tree.
+        assert result == ['@a/hmi']

--- a/test/test_unit_core.py
+++ b/test/test_unit_core.py
@@ -233,9 +233,7 @@ class TestGetAllDependencies:
 
     def test_dedupes_diamond_dependencies(self, tmp_path, monkeypatch):
         # A -> B, A -> C, B -> D, C -> D. D appears once in result.
-        self._writeManifest(
-            tmp_path, '@a/a', {'lpm': {'type': 'library'}, 'dependencies': {'@a/b': '*', '@a/c': '*'}}
-        )
+        self._writeManifest(tmp_path, '@a/a', {'lpm': {'type': 'library'}, 'dependencies': {'@a/b': '*', '@a/c': '*'}})
         self._writeManifest(tmp_path, '@a/b', {'lpm': {'type': 'library'}, 'dependencies': {'@a/d': '*'}})
         self._writeManifest(tmp_path, '@a/c', {'lpm': {'type': 'library'}, 'dependencies': {'@a/d': '*'}})
         self._writeManifest(tmp_path, '@a/d', {'lpm': {'type': 'library'}})


### PR DESCRIPTION
## Summary
`lpm install opcua-proxy` hangs indefinitely on 1.2.1. `getAllDependencies` walked every transitive npm dependency recursively, parsing each `package.json` along the way. `opcua-proxy` itself has no `lpm` config and pulls in `node-opcua` + `express` + `winston` + `ws`, whose collective transitive npm graph is hundreds of packages — the walk isn't infinite, just unreasonably slow. Users Ctrl+C before it finishes. Traceback shows ~17 stack frames of `getAllDependencies` calling itself.

Two layered fixes:

1. **Treat any package without an `lpm.type` field as a leaf.** npm has already placed those packages and there's nothing for lpm to sync from their transitive deps. Walking node-opcua's npm dep tree looking for Loupe libraries is wasted work. Critically, packages from non-loupeteam registries that *do* publish with an `lpm` config still get walked exactly like `@loupeteam/*` — only plain npm libs become leaves.
2. **Memoize visited packages within a single `getAllDependencies` call** via an internal `_seen` set so cycles and diamond deps don't re-walk the same subtree.

Also drops the unreachable source-library fallback branch — the `os.path.exists` guard added in #83 already short-circuits that path, so the `else` was dead code.

## Test plan
- [x] Local: `getAllDependencies(['@loupeteam/opcua-proxy'])` returns in 0.4s (was hanging).
- [x] Local: `getAllDependencies(['@loupeteam/atn'])` correctly returns `['@loupeteam/atn', '@loupeteam/stringext', '@loupeteam/vartools']` — proves lpm-managed transitive walking still works.
- [x] Local: `pytest test/test_unit_core.py` — 24/24 pass.
- [ ] Reviewer: run `lpm install opcua-proxy` end-to-end against a fresh project and confirm it completes.
- [ ] Reviewer: install an `@loupeteam/*` library with deep lpm-managed transitive deps and confirm dependent libraries still sync into `Logical/Libraries/Loupe/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)