### PR TITLE
Update starter project to latest

### DIFF
--- a/src/LPM.py
+++ b/src/LPM.py
@@ -282,8 +282,10 @@ def cmd_init(args):
             print(colored('This directory has been initialized as a stand-alone package manager.', 'green'))
         else:
             initializeProject()
-            starterProject = ['@loupeteam/starterasproject49']
-            installPackages(starterProject, [''])
+            starterProject = ['@loupeteam/starterasproject']
+            # Install the latest version; npm's default caret range in
+            # package.json pins us to compatible (non-major) upgrades.
+            installPackages(starterProject, ['latest'])
             syncPackages(starterProject)
             configureProject(args)
             print(colored('Your local directory is now ready to be used with LPM.', 'green'))


### PR DESCRIPTION
This pull request updates the default starter project and installation behavior when initializing a new project with LPM. The main change is to ensure that the latest compatible version of the starter project is installed by default.

**Initialization improvements:**

* Updated the default starter project from `@loupeteam/starterasproject49` to `@loupeteam/starterasproject`, and changed the installation to use the `latest` version tag, ensuring users get the most up-to-date compatible starter package.which is as6
