### PR TITLE
feat: show spinner during silent install/uninstall phases

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loupeteam/lpm",
-  "version": "1.3.0-beta.1",
+  "version": "1.3.0",
   "description": "LPM - Loupe Package Manager. A lightweight wrapper around NPM that processes Loupe packages.",
   "homepage": "https://loupeteam.github.io/LoupeDocs/tools/lpm.html",
   "repository": {

--- a/src/LPM.py
+++ b/src/LPM.py
@@ -319,7 +319,10 @@ def cmd_install(args):
             deps = getPackageManifestField('package.json', ['dependencies']) or {}
             packages = list(deps.keys())
         # Move packages from the node_modules folder into the project/main directory.
-        syncPackages(getAllDependencies(packages))
+        with spinner('Resolving dependencies'):
+            allDeps = getAllDependencies(packages)
+        with spinner('Syncing packages'):
+            syncPackages(allDeps)
         sourceDependencies = []
     else:
         if packages:
@@ -334,13 +337,15 @@ def cmd_install(args):
         print('Deploying ' + ', '.join(packages) + ' to the following configurations: ' + ', '.join(deploymentConfigs))
         for config in deploymentConfigs:
             if not args.source:
-                deployPackages(config, getAllDependencies(packages))
+                with spinner(f'Deploying to {config}'):
+                    deployPackages(config, getAllDependencies(packages))
             else:
                 # TODO: this split below may not be necessary, TBD.
                 # For case of source, deploy the source first.
-                deployPackages(config, packages)
-                # Then deploy all of its dependencies.
-                deployPackages(config, sourceDependencies)
+                with spinner(f'Deploying source to {config}'):
+                    deployPackages(config, packages)
+                    # Then deploy all of its dependencies.
+                    deployPackages(config, sourceDependencies)
     cprint('Operation completed successfully.', 'green')
     for package in packages:
         packageManifestPath = os.path.join('node_modules', package, 'package.json')
@@ -367,7 +372,10 @@ def cmd_uninstall(args):
     except:
         cprint('Error while attempting to uninstall package(s).', 'yellow')
         return
-    syncPackages(getAllDependencies(packages))
+    with spinner('Resolving dependencies'):
+        allDeps = getAllDependencies(packages)
+    with spinner('Syncing packages'):
+        syncPackages(allDeps)
     cprint('Operation completed successfully.', 'green')
 
 

--- a/src/lpm_core.py
+++ b/src/lpm_core.py
@@ -13,17 +13,51 @@ LPM.py and is responsible for argument parsing and user-facing output;
 everything else lives here so it can be reused and tested in isolation.
 """
 
+import itertools
 import json
 import os
 import os.path
 import re
 import shutil
 import subprocess
+import sys
+import threading
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
 
 import aspython as ASTools
 import requests
 from termcolor import colored, cprint
+
+
+@contextmanager
+def spinner(message):
+    # Show a rotating ASCII spinner while a silent phase runs so the user can
+    # tell lpm is still working. Falls back to a single static line when stdout
+    # isn't a TTY (CI logs, redirected output) so we don't spam carriage returns.
+    if not sys.stdout.isatty():
+        print(f'{message}...')
+        yield
+        return
+
+    stop_event = threading.Event()
+    frames = itertools.cycle('|/-\\')
+
+    def animate():
+        while not stop_event.is_set():
+            sys.stdout.write(f'\r{next(frames)} {message}...')
+            sys.stdout.flush()
+            stop_event.wait(0.1)
+
+    thread = threading.Thread(target=animate, daemon=True)
+    thread.start()
+    try:
+        yield
+    finally:
+        stop_event.set()
+        thread.join(timeout=0.5)
+        sys.stdout.write('\r' + ' ' * (len(message) + 6) + '\r')
+        sys.stdout.flush()
 
 
 def isAuthenticated():


### PR DESCRIPTION
## Summary
After `npm install` exits, lpm still runs `getAllDependencies` → `syncPackages` → `deployPackages` with no output. That silent gap is what made the pre-#84 hang feel indistinguishable from working behavior — and even with #84's perf fix, larger projects can spend real seconds in `syncPackages` looking frozen.

Adds a tiny threaded ASCII spinner context manager in [src/lpm_core.py](src/lpm_core.py) and wraps each silent phase in `cmd_install` / `cmd_uninstall` ([src/LPM.py](src/LPM.py)).

- ~30 lines, no new dependencies (stdlib `threading` + `itertools` + `contextlib`)
- Frames are plain ASCII (`|/-\`) — no Unicode/codepage risk on Windows cmd
- Daemon thread writes `\r| Resolving dependencies...` to stdout at 10 Hz; on exit it clears the line so subsequent output is clean
- **Non-TTY fallback**: when `sys.stdout.isatty()` is false (CI logs, redirected output) the spinner degrades to a single static `Resolving dependencies...` line — no carriage-return spam in pipeline logs

Spinner only runs *after* npm exits — npm has its own progress UI and we don't want to fight it.

## Test plan
- [x] `python -m pytest test/test_unit_core.py` — 31/31 pass
- [x] Non-TTY path verified locally (prints static line, no animation)
- [ ] Reviewer: run `lpm install opcua-proxy` in a TTY and confirm the spinner animates during the post-npm phases
- [ ] Reviewer: run `lpm install` redirected to a file (`lpm install opcua-proxy > out.txt`) and confirm `out.txt` contains static lines, not carriage-return garbage
- [ ] Reviewer: run `lpm uninstall <pkg>` and confirm the same spinner appears